### PR TITLE
feat: add check for new version

### DIFF
--- a/client/tests/test_version_command.py
+++ b/client/tests/test_version_command.py
@@ -1,0 +1,18 @@
+import logging
+
+from gefyra.__main__ import version_parser, version
+from gefyra import configuration
+
+
+def test_version_command(caplog):
+    with caplog.at_level(logging.INFO):
+        args = version_parser.parse_args()
+        version(configuration, not args.no_check)
+    assert "Gefyra client version" in caplog.text
+
+
+def test_version_command_no_check(caplog):
+    with caplog.at_level(logging.INFO):
+        args = version_parser.parse_args(["-n"])
+        version(configuration, not args.no_check)
+    assert "Gefyra client version" in caplog.text


### PR DESCRIPTION
Adds check whether there is a new version of gefyra published on
Github. Can be disabled by use `-n` or `--no-check` flag in `version`
command.
Simply parses Github release api page result and compares with current
version.