### PR TITLE
fix: check if container is running before deploying

### DIFF
--- a/client/gefyra/configuration.py
+++ b/client/gefyra/configuration.py
@@ -98,6 +98,7 @@ class ClientConfiguration(object):
         self.NETWORK_NAME = network_name or "gefyra"
         self.BRIDGE_TIMEOUT = 60  # in seconds
         self.CARGO_PROBE_TIMEOUT = 10  # in seconds
+        self.CONTAINER_RUN_TIMEOUT = 10  # in seconds
         self.KUBE_CONFIG_FILE = kube_config_file
 
     def _init_docker(self):

--- a/client/gefyra/local/bridge.py
+++ b/client/gefyra/local/bridge.py
@@ -151,6 +151,10 @@ def deploy_app_container(
     container = handle_docker_run_container(config, image, **not_none_kwargs)
 
     cargo = config.DOCKER.containers.get(config.CARGO_CONTAINER_NAME)
+
+    if container.status != "running":
+        raise RuntimeError("Container is not running. Did you miss a valid startup command?")
+
     exit_code, output = cargo.exec_run(
         f"bash patchContainerGateway.sh {container.name} {cargo_ip}"
     )

--- a/client/gefyra/local/bridge.py
+++ b/client/gefyra/local/bridge.py
@@ -153,7 +153,9 @@ def deploy_app_container(
     cargo = config.DOCKER.containers.get(config.CARGO_CONTAINER_NAME)
 
     if container.status != "running":
-        raise RuntimeError("Container is not running. Did you miss a valid startup command?")
+        raise RuntimeError(
+            "Container is not running. Did you miss a valid startup command?"
+        )
 
     exit_code, output = cargo.exec_run(
         f"bash patchContainerGateway.sh {container.name} {cargo_ip}"

--- a/client/gefyra/local/bridge.py
+++ b/client/gefyra/local/bridge.py
@@ -128,6 +128,7 @@ def deploy_app_container(
     auto_remove: bool = None,
     dns_search: str = "default",
 ) -> Container:
+    import docker
 
     gefyra_net = config.DOCKER.networks.get(config.NETWORK_NAME)
 
@@ -151,6 +152,20 @@ def deploy_app_container(
     container = handle_docker_run_container(config, image, **not_none_kwargs)
 
     cargo = config.DOCKER.containers.get(config.CARGO_CONTAINER_NAME)
+
+    # busy wait for the container to start
+    try:
+        _i = 0
+        while container.status == "created" and _i < (
+            config.CONTAINER_RUN_TIMEOUT * 10
+        ):
+            sleep(0.1)
+            container = config.DOCKER.containers.get(container.id)
+            _i = _i + 1
+    except docker.errors.NotFound:
+        raise RuntimeError(
+            "Container is not running. Did you miss a valid startup command?"
+        )
 
     if container.status != "running":
         raise RuntimeError(


### PR DESCRIPTION
Closes #75

Adds a check for the container status before deployment of container. If container is not running, an informative error message is displayed.