### PR TITLE
gefyra tab completion bash

### DIFF
--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -3,6 +3,7 @@ import argparse
 import logging
 
 from gefyra.configuration import ClientConfiguration
+from gefyra.local.telemetry import CliTelemetry
 
 logger = logging.getLogger("gefyra")
 parser = argparse.ArgumentParser(
@@ -150,6 +151,12 @@ version_parser.add_argument(
     default=False,
 )
 
+telemetry_parser = action.add_parser("telemetry")
+telemetry_parser.add_argument("--off", help="Turn off telemetry", action="store_true")
+telemetry_parser.add_argument("--on", help="Turn on telemetry", action="store_true")
+
+telemetry = CliTelemetry()
+
 
 def get_intercept_kwargs(parser_args):
     kwargs = {}
@@ -214,6 +221,15 @@ def version(config, check: bool):
             )
 
 
+def telemetry_command(on, off):
+    if off and not on:
+        telemetry.off()
+    elif on and not off:
+        telemetry.on()
+    else:
+        logger.info("Invalid flags. Please use either --off or --on.")
+
+
 def main():
     try:
         from gefyra import configuration
@@ -276,6 +292,8 @@ def main():
         elif args.action == "version":
             check = not args.no_check
             version(configuration, check)
+        elif args.action == "telemetry":
+            telemetry_command(on=args.on, off=args.off)
         else:
             parser.print_help()
     except Exception as e:

--- a/client/gefyra/local/telemetry.py
+++ b/client/gefyra/local/telemetry.py
@@ -1,0 +1,74 @@
+import configparser
+from pathlib import Path
+
+from cli_tracker.sdk import CliTracker
+
+
+class CliTelemetry:
+    dir_name = ".gefyra"
+    file_name = "config.ini"
+
+    def __init__(self):
+        home = Path.home()
+        gefyra_dir = home / self.dir_name
+        if gefyra_dir.exists():
+            gefyra_settings_path = gefyra_dir / self.file_name
+            if gefyra_settings_path.exists():
+                config = self.load_config(str(gefyra_settings_path))
+            else:
+                config = self.create_config(gefyra_settings_path)
+        else:
+            config = self.create_config(gefyra_dir / self.file_name)
+        try:
+            config["telemetry"].getboolean("track")
+        except KeyError:
+            config = self.create_config(gefyra_dir / self.file_name)
+
+        if config["telemetry"].getboolean("track"):
+            print("Tracking now")
+            self._init_tracker()
+        else:
+            print("No Tracking")
+
+    def _init_tracker(self):
+        self.tracker = CliTracker(
+            application="gefyra",
+            dsn="https://a94b0a0194b045f79897f70f9727d299@sentry.unikube.io/3",
+            release="0.8.1",
+        )
+
+    def load_config(self, path):
+        config = configparser.ConfigParser()
+        config.read(path)
+        self.path = path
+        return config
+
+    def create_config(self, path):
+        config = configparser.ConfigParser()
+        config["telemetry"] = {"track": "True"}
+
+        output_file = Path(path)
+        output_file.parent.mkdir(exist_ok=True, parents=True)
+
+        with open(str(output_file), "w") as config_file:
+            config.write(config_file)
+        self.path = path
+        return config
+
+    def off(self):
+        config = configparser.ConfigParser()
+        config.read(self.path)
+        config["telemetry"]["track"] = "False"
+        with open(str(self.path), "w") as config_file:
+            config.write(config_file)
+        if hasattr(self, "tracker"):
+            self.tracker.report_opt_out()
+
+    def on(self):
+        config = configparser.ConfigParser()
+        config.read(self.path)
+        config["telemetry"]["track"] = "True"
+        with open(str(self.path), "w") as config_file:
+            config.write(config_file)
+        self._init_tracker()
+        self.tracker.report_opt_in()

--- a/client/poetry.lock
+++ b/client/poetry.lock
@@ -70,6 +70,18 @@ python-versions = ">=3.5.0"
 unicode_backport = ["unicodedata2"]
 
 [[package]]
+name = "cli-tracker"
+version = "0.2.0"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=3.8,<4.0"
+
+[package.dependencies]
+distro = {version = ">=1.7.0,<2.0.0", markers = "sys_platform == \"linux\""}
+sentry-sdk = ">=1.5.12,<2.0.0"
+
+[[package]]
 name = "click"
 version = "8.0.4"
 description = "Composable command line interface toolkit"
@@ -117,6 +129,14 @@ requests = ">=1.0.0"
 
 [package.extras]
 yaml = ["PyYAML (>=3.10)"]
+
+[[package]]
+name = "distro"
+version = "1.7.0"
+description = "Distro - an OS platform information API"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "docker"
@@ -460,6 +480,36 @@ python-versions = ">=3.6,<4"
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "sentry-sdk"
+version = "1.6.0"
+description = "Python client for Sentry (https://sentry.io)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+certifi = "*"
+urllib3 = ">=1.10.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.5)"]
+beam = ["apache-beam (>=2.12)"]
+bottle = ["bottle (>=0.12.13)"]
+celery = ["celery (>=3)"]
+chalice = ["chalice (>=1.16.0)"]
+django = ["django (>=1.8)"]
+falcon = ["falcon (>=1.4)"]
+flask = ["flask (>=0.11)", "blinker (>=1.1)"]
+httpx = ["httpx (>=0.16.0)"]
+pure_eval = ["pure-eval", "executing", "asttokens"]
+pyspark = ["pyspark (>=2.4.4)"]
+quart = ["quart (>=0.16.1)", "blinker (>=1.1)"]
+rq = ["rq (>=0.6)"]
+sanic = ["sanic (>=0.8)"]
+sqlalchemy = ["sqlalchemy (>=1.2)"]
+tornado = ["tornado (>=5)"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -520,7 +570,7 @@ test = ["websockets"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "7938617d53fa835735aadfd02f55eebd354cb1e49181c26631b3c1aa52797f34"
+content-hash = "3c5c507ce8427b4752d7270621606e010137fac72b909469ce61fed17d521ce4"
 
 [metadata.files]
 atomicwrites = [
@@ -567,6 +617,10 @@ certifi = [
 charset-normalizer = [
     {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+]
+cli-tracker = [
+    {file = "cli_tracker-0.2.0-py3-none-any.whl", hash = "sha256:4ac60975e93abd1f97c48ded0aaba7f0e5174ec599c22c89f76884df01b50a7b"},
+    {file = "cli_tracker-0.2.0.tar.gz", hash = "sha256:adac46c1e960417c4677a36ea5ca40e353b130298ab4c629562b5c03e16cca2c"},
 ]
 click = [
     {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
@@ -622,6 +676,10 @@ coverage = [
 coveralls = [
     {file = "coveralls-3.3.1-py2.py3-none-any.whl", hash = "sha256:f42015f31d386b351d4226389b387ae173207058832fbf5c8ec4b40e27b16026"},
     {file = "coveralls-3.3.1.tar.gz", hash = "sha256:b32a8bb5d2df585207c119d6c01567b81fba690c9c10a753bfe27a335bfc43ea"},
+]
+distro = [
+    {file = "distro-1.7.0-py3-none-any.whl", hash = "sha256:d596311d707e692c2160c37807f83e3820c5d539d5a83e87cfb6babd8ba3a06b"},
+    {file = "distro-1.7.0.tar.gz", hash = "sha256:151aeccf60c216402932b52e40ee477a939f8d58898927378a02abbe852c1c39"},
 ]
 docker = [
     {file = "docker-5.0.3-py2.py3-none-any.whl", hash = "sha256:7a79bb439e3df59d0a72621775d600bc8bc8b422d285824cb37103eab91d1ce0"},
@@ -800,6 +858,10 @@ requests-oauthlib = [
 rsa = [
     {file = "rsa-4.8-py3-none-any.whl", hash = "sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb"},
     {file = "rsa-4.8.tar.gz", hash = "sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17"},
+]
+sentry-sdk = [
+    {file = "sentry-sdk-1.6.0.tar.gz", hash = "sha256:b82ad57306d5546713f15d5d70daea0408cf7f998c7566db16e0e6257e51e561"},
+    {file = "sentry_sdk-1.6.0-py2.py3-none-any.whl", hash = "sha256:ddbd191b6f4e696b7845b4d87389898ae1207981faf114f968a57363aa6be03c"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 python = "^3.8"
 kubernetes = "^19.15.0"
 docker = "^5.0.3"
+cli-tracker = "^0.2.0"
 
 [tool.poetry.dev-dependencies]
 flake8-bugbear = "^22.1.11"

--- a/completion.bash
+++ b/completion.bash
@@ -1,227 +1,32 @@
 
-__unikube_complete_flags_app() {
-    if [[ $com == $prev ]]; then
-        opts="${opts} --help"
-    else
-        case "$prev" in
-
-        (env)
-            opts="${opts} --init --organization --project --deck --help"
-            ;;
-
-        (exec)
-            opts="${opts} --organization --project --deck --help"
-            ;;
-
-        (info)
-            opts="${opts} --organization --project --deck --help"
-            ;;
-
-        (list)
-            opts="${opts} --organization --project --deck --help"
-            ;;
-
-        (logs)
-            opts="${opts} --container --organization --project --deck --follow --help"
-            ;;
-
-        (shell)
-            opts="${opts} --organization --project --deck --container --help"
-            ;;
-
-        (switch)
-            opts="${opts} --organization --project --deck --deployment --unikubefile --no-build --help"
-            ;;
-
-        (update)
-            opts="${opts} --organization --project --deck --help"
-            ;;
-        esac
-    fi
+__gefyra_complete_flags_up() {
+    opts="${opts} --endpoint --operator --stowaway --carrier --cargo --registry --help"
 }
 
-
-__unikube_complete_flags_auth() {
-    if [[ $com == $prev ]]; then
-        opts="${opts} --help"
-    else
-        case "$prev" in
-
-        (login)
-            opts="${opts} --email --password --help"
-            ;;
-
-        (logout)
-            opts="${opts} --help"
-            ;;
-
-        (status)
-            opts="${opts} --token --help"
-            ;;
-        esac
-    fi
+__gefyra_complete_flags_run() {
+    opts="${opts} --image --name --command --namespace --env --volume --env-from --help"
 }
 
-
-__unikube_complete_flags_context() {
-    if [[ $com == $prev ]]; then
-        opts="${opts} --help"
-    else
-        case "$prev" in
-
-        (remove)
-            opts="${opts} --organization --project --deck --help"
-            ;;
-
-        (set)
-            opts="${opts} --organization --project --deck --help"
-            ;;
-
-        (show)
-            opts="${opts} --help"
-            ;;
-        esac
-    fi
+__gefyra_complete_flags_bridge() {
+    opts="${opts} --name --container-name --bridge-name --port --namespace --no-probe-handling --help --deployment --statefulset --pod --container"
 }
 
-
-__unikube_complete_flags_deck() {
-    if [[ $com == $prev ]]; then
-        opts="${opts} --help"
-    else
-        case "$prev" in
-
-        (info)
-            opts="${opts} --organization --project --help"
-            ;;
-
-        (ingress)
-            opts="${opts} --organization --project --help"
-            ;;
-
-        (install)
-            opts="${opts} --organization --project --help"
-            ;;
-
-        (list)
-            opts="${opts} --organization --project --help"
-            ;;
-
-        (uninstall)
-            opts="${opts} --organization --project --help"
-            ;;
-        esac
-    fi
+__gefyra_complete_flags_unbridge() {
+    opts="${opts} --name --all --help"
 }
 
-
-__unikube_complete_flags_install() {
-    opts="${opts} --organization --project --help"
+__gefyra_complete_flags_list() {
+    opts="${opts} --containers --bridges --help"
 }
 
-
-__unikube_complete_flags_login() {
-    opts="${opts} --email --password --help"
+__gefyra_complete_flags_version() {
+    opts="${opts} --no-check"
 }
 
-
-__unikube_complete_flags_logout() {
+__gefyra_complete_flags_noargs() {
     opts="${opts} --help"
 }
 
-
-__unikube_complete_flags_orga() {
-    if [[ $com == $prev ]]; then
-        opts="${opts} --help"
-    else
-        case "$prev" in
-
-        (info)
-            opts="${opts} --help"
-            ;;
-
-        (list)
-            opts="${opts} --help"
-            ;;
-        esac
-    fi
-}
-
-
-__unikube_complete_flags_project() {
-    if [[ $com == $prev ]]; then
-        opts="${opts} --help"
-    else
-        case "$prev" in
-
-        (delete)
-            opts="${opts} --organization --help"
-            ;;
-
-        (down)
-            opts="${opts} --organization --help"
-            ;;
-
-        (info)
-            opts="${opts} --organization --help"
-            ;;
-
-        (list)
-            opts="${opts} --organization --help"
-            ;;
-
-        (prune)
-            opts="${opts} --help"
-            ;;
-
-        (up)
-            opts="${opts} --organization --ingress --provider --workers --help"
-            ;;
-        esac
-    fi
-}
-
-
-__unikube_complete_flags_ps() {
-    opts="${opts} --help"
-}
-
-
-__unikube_complete_flags_shell() {
-    opts="${opts} --organization --project --deck --container --help"
-}
-
-
-__unikube_complete_flags_system() {
-    if [[ $com == $prev ]]; then
-        opts="${opts} --help"
-    else
-        case "$prev" in
-
-        (completion)
-            opts="${opts} --help"
-            ;;
-
-        (install)
-            opts="${opts} --reinstall --help"
-            ;;
-
-        (verify)
-            opts="${opts} --verbose --help"
-            ;;
-        esac
-    fi
-}
-
-
-__unikube_complete_flags_up() {
-    opts="${opts} --organization --ingress --provider --workers --help"
-}
-
-
-__unikube_complete_flags_version() {
-    opts="${opts} --help"
-}
 
 _gefyra_complete()
 {
@@ -246,61 +51,36 @@ _gefyra_complete()
     if [[ ${cur} == --* ]] ; then
         opts=""
         case "$com" in
-
-            (app)
-                __unikube_complete_flags_app
-                ;;
-
-            (auth)
-                __unikube_complete_flags_auth
-                ;;
-
-            (context)
-                __unikube_complete_flags_context
-                ;;
-
-            (deck)
-                __unikube_complete_flags_deck
-                ;;
-
-            (install)
-                __unikube_complete_flags_install
-                ;;
-
-            (login)
-                __unikube_complete_flags_login
-                ;;
-
-            (logout)
-                __unikube_complete_flags_logout
-                ;;
-
-            (orga)
-                __unikube_complete_flags_orga
-                ;;
-
-            (project)
-                __unikube_complete_flags_project
-                ;;
-
-            (ps)
-                __unikube_complete_flags_ps
-                ;;
-
-            (shell)
-                __unikube_complete_flags_shell
-                ;;
-
-            (system)
-                __unikube_complete_flags_system
-                ;;
-
             (up)
-                __unikube_complete_flags_up
+                __gefyra_complete_flags_up
+                ;;
+
+            (run)
+                __gefyra_complete_flags_run
+                ;;
+
+            (bridge)
+                __gefyra_complete_flags_bridge
+                ;;
+
+            (unbridge)
+                __gefyra_complete_flags_unbridge
+                ;;
+
+            (list)
+                __gefyra_complete_flags_list
                 ;;
 
             (version)
-                __unikube_complete_flags_version
+                __gefyra_complete_flags_version
+                ;;
+
+            (down)
+                __gefyra_complete_flags_noargs
+                ;;
+
+            (check)
+                __gefyra_complete_flags_noargs
                 ;;
         esac
         COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
@@ -308,70 +88,47 @@ _gefyra_complete()
         return 0;
     fi
 
-    if [[ $prev == $com ]]; then
+    if [[ $prev != $com ]]; then
         case "$com" in
-            
-    (app)
-        coms="env exec info list logs shell switch update"
-        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
-        __ltrim_colon_completions "$cur"
-        return 0;
+        (bridge)
+          case $prev in
+          (--name)
+            coms=$(docker ps --format '{{ .Names }}' | tr '\n' ' ')
+            COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+            __ltrim_colon_completions "$cur"
+            return 0;
+            ;;
+          (--namespace)
+            coms=$(kubectl get ns --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+            COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+            __ltrim_colon_completions "$cur"
+            return 0;
+            ;;
+          esac
         ;;
-    
+        (run)
+          case $prev in
+          (--image)
+            coms=$(docker image ls --format '{{ .Repository }}' | tr '\n' ' ')
+            COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+            __ltrim_colon_completions "$cur"
+            return 0;
+            ;;
 
-    (auth)
-        coms="login logout status"
-        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
-        __ltrim_colon_completions "$cur"
-        return 0;
+          (--namespace)
+            coms=$(kubectl get ns --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+            COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+            __ltrim_colon_completions "$cur"
+            return 0;
+            ;;
+          esac
         ;;
-    
-
-    (context)
-        coms="remove set show"
-        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
-        __ltrim_colon_completions "$cur"
-        return 0;
-        ;;
-    
-
-    (deck)
-        coms="info ingress install list uninstall"
-        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
-        __ltrim_colon_completions "$cur"
-        return 0;
-        ;;
-    
-
-    (orga)
-        coms="info list"
-        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
-        __ltrim_colon_completions "$cur"
-        return 0;
-        ;;
-    
-
-    (project)
-        coms="delete down info list prune up"
-        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
-        __ltrim_colon_completions "$cur"
-        return 0;
-        ;;
-    
-
-    (run)
-        coms=$(docker ps --format '{{ .Names }}' | tr '\n' ' ')
-        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
-        __ltrim_colon_completions "$cur"
-        return 0;
-        ;;
-    
         esac
     fi
 
     # completing for a command
     if [[ $cur == $com ]]; then
-        coms="run"
+        coms="up run bridge unbridge version check list down"
         COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
         __ltrim_colon_completions "$cur"
         return 0

--- a/completion.bash
+++ b/completion.bash
@@ -1,0 +1,380 @@
+
+__unikube_complete_flags_app() {
+    if [[ $com == $prev ]]; then
+        opts="${opts} --help"
+    else
+        case "$prev" in
+
+        (env)
+            opts="${opts} --init --organization --project --deck --help"
+            ;;
+
+        (exec)
+            opts="${opts} --organization --project --deck --help"
+            ;;
+
+        (info)
+            opts="${opts} --organization --project --deck --help"
+            ;;
+
+        (list)
+            opts="${opts} --organization --project --deck --help"
+            ;;
+
+        (logs)
+            opts="${opts} --container --organization --project --deck --follow --help"
+            ;;
+
+        (shell)
+            opts="${opts} --organization --project --deck --container --help"
+            ;;
+
+        (switch)
+            opts="${opts} --organization --project --deck --deployment --unikubefile --no-build --help"
+            ;;
+
+        (update)
+            opts="${opts} --organization --project --deck --help"
+            ;;
+        esac
+    fi
+}
+
+
+__unikube_complete_flags_auth() {
+    if [[ $com == $prev ]]; then
+        opts="${opts} --help"
+    else
+        case "$prev" in
+
+        (login)
+            opts="${opts} --email --password --help"
+            ;;
+
+        (logout)
+            opts="${opts} --help"
+            ;;
+
+        (status)
+            opts="${opts} --token --help"
+            ;;
+        esac
+    fi
+}
+
+
+__unikube_complete_flags_context() {
+    if [[ $com == $prev ]]; then
+        opts="${opts} --help"
+    else
+        case "$prev" in
+
+        (remove)
+            opts="${opts} --organization --project --deck --help"
+            ;;
+
+        (set)
+            opts="${opts} --organization --project --deck --help"
+            ;;
+
+        (show)
+            opts="${opts} --help"
+            ;;
+        esac
+    fi
+}
+
+
+__unikube_complete_flags_deck() {
+    if [[ $com == $prev ]]; then
+        opts="${opts} --help"
+    else
+        case "$prev" in
+
+        (info)
+            opts="${opts} --organization --project --help"
+            ;;
+
+        (ingress)
+            opts="${opts} --organization --project --help"
+            ;;
+
+        (install)
+            opts="${opts} --organization --project --help"
+            ;;
+
+        (list)
+            opts="${opts} --organization --project --help"
+            ;;
+
+        (uninstall)
+            opts="${opts} --organization --project --help"
+            ;;
+        esac
+    fi
+}
+
+
+__unikube_complete_flags_install() {
+    opts="${opts} --organization --project --help"
+}
+
+
+__unikube_complete_flags_login() {
+    opts="${opts} --email --password --help"
+}
+
+
+__unikube_complete_flags_logout() {
+    opts="${opts} --help"
+}
+
+
+__unikube_complete_flags_orga() {
+    if [[ $com == $prev ]]; then
+        opts="${opts} --help"
+    else
+        case "$prev" in
+
+        (info)
+            opts="${opts} --help"
+            ;;
+
+        (list)
+            opts="${opts} --help"
+            ;;
+        esac
+    fi
+}
+
+
+__unikube_complete_flags_project() {
+    if [[ $com == $prev ]]; then
+        opts="${opts} --help"
+    else
+        case "$prev" in
+
+        (delete)
+            opts="${opts} --organization --help"
+            ;;
+
+        (down)
+            opts="${opts} --organization --help"
+            ;;
+
+        (info)
+            opts="${opts} --organization --help"
+            ;;
+
+        (list)
+            opts="${opts} --organization --help"
+            ;;
+
+        (prune)
+            opts="${opts} --help"
+            ;;
+
+        (up)
+            opts="${opts} --organization --ingress --provider --workers --help"
+            ;;
+        esac
+    fi
+}
+
+
+__unikube_complete_flags_ps() {
+    opts="${opts} --help"
+}
+
+
+__unikube_complete_flags_shell() {
+    opts="${opts} --organization --project --deck --container --help"
+}
+
+
+__unikube_complete_flags_system() {
+    if [[ $com == $prev ]]; then
+        opts="${opts} --help"
+    else
+        case "$prev" in
+
+        (completion)
+            opts="${opts} --help"
+            ;;
+
+        (install)
+            opts="${opts} --reinstall --help"
+            ;;
+
+        (verify)
+            opts="${opts} --verbose --help"
+            ;;
+        esac
+    fi
+}
+
+
+__unikube_complete_flags_up() {
+    opts="${opts} --organization --ingress --provider --workers --help"
+}
+
+
+__unikube_complete_flags_version() {
+    opts="${opts} --help"
+}
+
+_gefyra_complete()
+{
+    local cur script coms opts com
+    COMPREPLY=()
+    _get_comp_words_by_ref -n : cur prev words
+    # for an alias, get the real script behind it
+    if [[ $(type -t ${words[0]}) == "alias" ]]; then
+        script=$(alias ${words[0]} | sed -E "s/alias ${words[0]}='(.*)'/\1/")
+    else
+        script=${words[0]}
+    fi
+    # lookup for command
+    for word in ${words[@]:1}; do
+        if [[ $word != -* ]]; then
+            com=$word
+            break
+        fi
+    done
+
+    # completing for an option
+    if [[ ${cur} == --* ]] ; then
+        opts=""
+        case "$com" in
+
+            (app)
+                __unikube_complete_flags_app
+                ;;
+
+            (auth)
+                __unikube_complete_flags_auth
+                ;;
+
+            (context)
+                __unikube_complete_flags_context
+                ;;
+
+            (deck)
+                __unikube_complete_flags_deck
+                ;;
+
+            (install)
+                __unikube_complete_flags_install
+                ;;
+
+            (login)
+                __unikube_complete_flags_login
+                ;;
+
+            (logout)
+                __unikube_complete_flags_logout
+                ;;
+
+            (orga)
+                __unikube_complete_flags_orga
+                ;;
+
+            (project)
+                __unikube_complete_flags_project
+                ;;
+
+            (ps)
+                __unikube_complete_flags_ps
+                ;;
+
+            (shell)
+                __unikube_complete_flags_shell
+                ;;
+
+            (system)
+                __unikube_complete_flags_system
+                ;;
+
+            (up)
+                __unikube_complete_flags_up
+                ;;
+
+            (version)
+                __unikube_complete_flags_version
+                ;;
+        esac
+        COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
+        return 0;
+    fi
+
+    if [[ $prev == $com ]]; then
+        case "$com" in
+            
+    (app)
+        coms="env exec info list logs shell switch update"
+        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
+        return 0;
+        ;;
+    
+
+    (auth)
+        coms="login logout status"
+        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
+        return 0;
+        ;;
+    
+
+    (context)
+        coms="remove set show"
+        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
+        return 0;
+        ;;
+    
+
+    (deck)
+        coms="info ingress install list uninstall"
+        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
+        return 0;
+        ;;
+    
+
+    (orga)
+        coms="info list"
+        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
+        return 0;
+        ;;
+    
+
+    (project)
+        coms="delete down info list prune up"
+        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
+        return 0;
+        ;;
+    
+
+    (run)
+        coms=$(docker ps --format '{{ .Names }}' | tr '\n' ' ')
+        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
+        return 0;
+        ;;
+    
+        esac
+    fi
+
+    # completing for a command
+    if [[ $cur == $com ]]; then
+        coms="run"
+        COMPREPLY=($(compgen -W "${coms}" -- ${cur}))
+        __ltrim_colon_completions "$cur"
+        return 0
+    fi
+}
+complete -o default -F _gefyra_complete gefyra


### PR DESCRIPTION
This is just a draft on how it could look like to make the use of gefyra more pleasant. Pretty much copied the [unikube cli](https://github.com/unikubehq/cli) completion and adapted the name and completion for `gefyra run`.

What this does: it extract the container names from `docker ps` and offers them as completion for `gefyra run`. This is obviously not correct, since it should be completed for a flag. 

ToDos:
- [ ] Implement command completion correctly
- [ ] Implement flag completion
  - [ ] make use of `docker`
  - [ ] make use of `kubectl`
- [ ] Add `gefyra completion bash` command for sourcing

I'm not to familiar with go templating - currently I'm using `tr` to replace newlines through spaces. Maybe there is a more elegant way to do this directly with the `--format` flag and the go template language. Help is really appreciated.