### PR TITLE
Telemetry for cli usage

### DIFF
--- a/.github/workflows/dist-build-mac.yaml
+++ b/.github/workflows/dist-build-mac.yaml
@@ -69,7 +69,7 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:
-        name: gefyra-${{ env.APP_VERSION }}-darwin-amd64
+        name: gefyra-${{ env.APP_VERSION }}-darwin-universal
         path: |
           gefyra
           LICENSE
@@ -77,9 +77,9 @@ jobs:
         retention-days: 5
     - name: Create release zip
       if: ${{ github.event.release && github.event.action == 'published' }}
-      run: zip gefyra-${{ env.APP_VERSION }}-darwin-amd64.zip "gefyra" "LICENSE" "README.md"
+      run: zip gefyra-${{ env.APP_VERSION }}-darwin-universal.zip "gefyra" "LICENSE" "README.md"
     - name: Attach files to release
       uses: softprops/action-gh-release@v1
       if: ${{ github.event.release && github.event.action == 'published' }}
       with:
-        files: gefyra-${{ env.APP_VERSION }}-darwin-amd64.zip
+        files: gefyra-${{ env.APP_VERSION }}-darwin-universal.zip

--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -88,14 +88,14 @@ jobs:
       working-directory: ./client
       shell: bash --noprofile --norc -o pipefail {0}
       run: |
-        poetry run coverage run -a -m gefyra run -i pyserver -N mypyserver -n default --port 8000
+        poetry run coverage run -a -m gefyra run -i pyserver -N mypyserver -n default --expose 8000
         test $? -eq 1
         curl localhost:8000
         test $? -ne 0
     - name: Run gefyra run with localhost port mapping
       working-directory: ./client
       run: |
-        poetry run coverage run -a -m gefyra run -i pyserver -N mypyserver -n default --port 8000:8000
+        poetry run coverage run -a -m gefyra run -i pyserver -N mypyserver -n default --expose 8000:8000
         test $? -eq 0
         curl localhost:8000
         test $? -eq 0

--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -76,6 +76,14 @@ jobs:
     - name: Apply some workload
       run: |
         kubectl apply -f testing/workloads/hello.yaml
+    - name: Set Gefyra to no tracking
+      shell: bash
+      run: |
+        mkdir ~/.gefyra
+        cd ~/gefyra
+        touch config
+        echo [telemetry] >> config
+        echo track = False >> config
     - name: Run gefyra up
       working-directory: ./client
       run: |

--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -66,8 +66,8 @@ jobs:
         mkdir -p ~/.gefyra
         cd ~/.gefyra
         touch config
-        echo [telemetry] >> config
-        echo track = False >> config
+        echo "[telemetry]" >> config
+        echo "track = False" >> config
     - name: Pytest
       working-directory: ./client
       run: |

--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -65,9 +65,9 @@ jobs:
       run: |
         mkdir -p ~/.gefyra
         cd ~/.gefyra
-        touch config
-        echo "[telemetry]" >> config
-        echo "track = False" >> config
+        touch config.ini
+        echo "[telemetry]" >> config.ini
+        echo "track = False" >> config.ini
     - name: Pytest
       working-directory: ./client
       run: |

--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -60,6 +60,14 @@ jobs:
         python-version: '3.x'
     - name: Install Poetry
       uses: snok/install-poetry@v1
+    - name: Set Gefyra to no tracking
+      shell: bash
+      run: |
+        mkdir -p ~/.gefyra
+        cd ~/.gefyra
+        touch config
+        echo [telemetry] >> config
+        echo track = False >> config
     - name: Pytest
       working-directory: ./client
       run: |
@@ -76,14 +84,6 @@ jobs:
     - name: Apply some workload
       run: |
         kubectl apply -f testing/workloads/hello.yaml
-    - name: Set Gefyra to no tracking
-      shell: bash
-      run: |
-        mkdir -p ~/.gefyra
-        cd ~/.gefyra
-        touch config
-        echo [telemetry] >> config
-        echo track = False >> config
     - name: Run gefyra up
       working-directory: ./client
       run: |

--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -80,7 +80,7 @@ jobs:
       shell: bash
       run: |
         mkdir -p ~/.gefyra
-        cd ~/gefyra
+        cd ~/.gefyra
         touch config
         echo [telemetry] >> config
         echo track = False >> config

--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -79,7 +79,7 @@ jobs:
     - name: Set Gefyra to no tracking
       shell: bash
       run: |
-        mkdir ~/.gefyra
+        mkdir -p ~/.gefyra
         cd ~/gefyra
         touch config
         echo [telemetry] >> config

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -4,6 +4,7 @@ import logging
 
 from gefyra.api import get_containers_and_print, get_bridges_and_print
 from gefyra.configuration import ClientConfiguration
+from gefyra.local.telemetry import CliTelemetry
 from gefyra.local.utils import PortMappingParser, IpPortMappingParser
 from gefyra.local.telemetry import CliTelemetry
 

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -5,6 +5,7 @@ import logging
 from gefyra.api import get_containers_and_print, get_bridges_and_print
 from gefyra.configuration import ClientConfiguration
 from gefyra.local.utils import PortMappingParser, IpPortMappingParser
+from gefyra.local.telemetry import CliTelemetry
 
 logger = logging.getLogger("gefyra")
 parser = argparse.ArgumentParser(
@@ -163,6 +164,15 @@ version_parser.add_argument(
     default=False,
 )
 
+telemetry_parser = action.add_parser("telemetry")
+telemetry_parser.add_argument("--off", help="Turn off telemetry", action="store_true")
+telemetry_parser.add_argument("--on", help="Turn on telemetry", action="store_true")
+
+try:
+    telemetry = CliTelemetry()
+except Exception:
+    telemetry = False
+
 
 def get_intercept_kwargs(parser_args):
     kwargs = {}
@@ -205,6 +215,17 @@ def version(config, check: bool):
                 f"You are using gefyra version {config.__VERSION__}; however, version {latest_release_version} is "
                 f"available."
             )
+
+
+def telemetry_command(on, off):
+    if not telemetry:
+        logger.info("Telemetry in not working on your machine. No action taken.")
+    if off and not on:
+        telemetry.off()
+    elif on and not off:
+        telemetry.on()
+    else:
+        logger.info("Invalid flags. Please use either --off or --on.")
 
 
 def main():
@@ -273,6 +294,8 @@ def main():
         elif args.action == "version":
             check = not args.no_check
             version(configuration, check)
+        elif args.action == "telemetry":
+            telemetry_command(on=args.on, off=args.off)
         else:
             parser.print_help()
     except Exception as e:

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -4,7 +4,6 @@ import logging
 
 from gefyra.api import get_containers_and_print, get_bridges_and_print
 from gefyra.configuration import ClientConfiguration
-from gefyra.local.telemetry import CliTelemetry
 from gefyra.local.utils import PortMappingParser, IpPortMappingParser
 from gefyra.local.telemetry import CliTelemetry
 

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -4,7 +4,7 @@ import logging
 
 from gefyra.api import get_containers_and_print, get_bridges_and_print
 from gefyra.configuration import ClientConfiguration
-from gefyra.local.utils import StoreDictKeyPair
+from gefyra.local.utils import PortMappingParser, IpPortMappingParser
 
 logger = logging.getLogger("gefyra")
 parser = argparse.ArgumentParser(
@@ -91,10 +91,11 @@ run_parser.add_argument(
     required=False,
 )
 run_parser.add_argument(
-    "--port",
+    "-p",
+    "--expose",
     help="Add port mapping in form of <container_port>:<host_port>",
     required=False,
-    action=StoreDictKeyPair,
+    action=IpPortMappingParser,
 )
 bridge_parser = action.add_parser("bridge")
 bridge_parser.add_argument(
@@ -114,7 +115,7 @@ bridge_parser.add_argument(
     "--port",
     help="Add port mapping in form of <container_port>:<host_port>",
     required=True,
-    action=StoreDictKeyPair,
+    action=PortMappingParser,
 )
 bridge_parser.add_argument(
     "-n",
@@ -234,7 +235,7 @@ def main():
                 namespace=args.namespace,
                 env_from=args.env_from,
                 env=args.env,
-                ports=args.port,
+                ports=args.expose,
                 volumes=args.volume,
             )
         elif args.action == "bridge":

--- a/client/gefyra/local/telemetry.py
+++ b/client/gefyra/local/telemetry.py
@@ -1,0 +1,90 @@
+import configparser
+import logging
+from pathlib import Path
+
+from cli_tracker.sdk import CliTracker
+from gefyra.configuration import __VERSION__
+
+logger = logging.getLogger("gefyra")
+
+#########################################################################################
+# Telemetry information
+# We are collecting anonymous data about the usage of Gefyra as CLI
+# All the data we collect is published here: ``
+# This data is supposed to help us develop Gefyra and make it a better tool, prioritize
+# issues and work on bugs, features and review of pull requests.
+# If you do not which to send telemetry data this is totally fine.
+# Just opt out via `gefyra telemetry --off`.
+#########################################################################################
+
+SENTRY_DSN = "https://a94b0a0194b045f79897f70f9727d299@sentry.unikube.io/3"
+
+
+class CliTelemetry:
+    dir_name = ".gefyra"
+    file_name = "config.ini"
+
+    def __init__(self):
+        # We're loading / creating a settings file in the home directory.
+        home = Path.home()
+        gefyra_dir = home / self.dir_name
+        if gefyra_dir.exists():
+            gefyra_settings_path = gefyra_dir / self.file_name
+            if gefyra_settings_path.exists():
+                config = self.load_config(str(gefyra_settings_path))
+            else:
+                config = self.create_config(gefyra_settings_path)
+        else:
+            config = self.create_config(gefyra_dir / self.file_name)
+        try:
+            config["telemetry"].getboolean("track")
+        except KeyError:
+            config = self.create_config(gefyra_dir / self.file_name)
+
+        if config["telemetry"].getboolean("track"):
+            self._init_tracker()
+
+    def _init_tracker(self):
+        self.tracker = CliTracker(
+            application="gefyra",
+            dsn=SENTRY_DSN,
+            release=__VERSION__,
+        )
+
+    def load_config(self, path):
+        config = configparser.ConfigParser()
+        config.read(path)
+        self.path = path
+        return config
+
+    def create_config(self, path):
+        config = configparser.ConfigParser()
+        config["telemetry"] = {"track": "True"}
+
+        output_file = Path(path)
+        output_file.parent.mkdir(exist_ok=True, parents=True)
+
+        with open(str(output_file), "w") as config_file:
+            config.write(config_file)
+        self.path = path
+        return config
+
+    def off(self):
+        config = configparser.ConfigParser()
+        config.read(self.path)
+        config["telemetry"]["track"] = "False"
+        with open(str(self.path), "w") as config_file:
+            config.write(config_file)
+        if hasattr(self, "tracker"):
+            self.tracker.report_opt_out()
+        logger.info("Disabled telemetry.")
+
+    def on(self):
+        config = configparser.ConfigParser()
+        config.read(self.path)
+        config["telemetry"]["track"] = "True"
+        with open(str(self.path), "w") as config_file:
+            config.write(config_file)
+        self._init_tracker()
+        self.tracker.report_opt_in()
+        logger.info("Enabled telemetry.")

--- a/client/gefyra/local/utils.py
+++ b/client/gefyra/local/utils.py
@@ -129,18 +129,41 @@ def handle_docker_run_container(
     return config.DOCKER.containers.run(image, **kwargs)
 
 
-class StoreDictKeyPair(argparse.Action):
+class PortMappingParser(argparse.Action):
     """Adapted from https://stackoverflow.com/questions/29986185/python-argparse-dict-arg"""
+
+    def parse_split(self, split):
+        # port - port
+        res = {}
+        if len(split) == 2:
+            res[split[1]] = split[0]
+            return res
+        else:
+            raise ValueError
 
     def __call__(self, parser, namespace, values, option_string=None):
         my_dict = {}
         try:
             for kv in values.split(","):
-                k, v = kv.split(":")
-                my_dict[k] = v
+                res = kv.split(":")
+                my_dict.update(self.parse_split(res))
         except Exception:
             logger.error(
-                "Invalid port mapping. Example valid port mapping: 8080:8081 (container_port:host_port)."
+                "Invalid port mapping. Example valid port mapping: 8080:8081 (<ip>:host_port:container_port)."
             )
             exit(1)
         setattr(namespace, self.dest, my_dict)
+
+
+class IpPortMappingParser(PortMappingParser):
+    def parse_split(self, split):
+        # port - port
+        res = {}
+        if len(split) == 2:
+            res[split[1]] = split[0]
+            return res
+        elif len(split) == 3:
+            res[split[2]] = (split[0], split[1])
+            return res
+        else:
+            raise ValueError

--- a/client/poetry.lock
+++ b/client/poetry.lock
@@ -70,6 +70,18 @@ python-versions = ">=3.6.0"
 unicode_backport = ["unicodedata2"]
 
 [[package]]
+name = "cli-tracker"
+version = "0.2.5"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=3.8,<4.0"
+
+[package.dependencies]
+distro = {version = ">=1.7.0,<2.0.0", markers = "sys_platform == \"linux\""}
+sentry-sdk = ">=1.5.12,<2.0.0"
+
+[[package]]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
@@ -117,6 +129,14 @@ requests = ">=1.0.0"
 
 [package.extras]
 yaml = ["PyYAML (>=3.10)"]
+
+[[package]]
+name = "distro"
+version = "1.7.0"
+description = "Distro - an OS platform information API"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "docker"
@@ -461,6 +481,36 @@ python-versions = ">=3.6,<4"
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "sentry-sdk"
+version = "1.6.0"
+description = "Python client for Sentry (https://sentry.io)"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+certifi = "*"
+urllib3 = ">=1.10.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.5)"]
+beam = ["apache-beam (>=2.12)"]
+bottle = ["bottle (>=0.12.13)"]
+celery = ["celery (>=3)"]
+chalice = ["chalice (>=1.16.0)"]
+django = ["django (>=1.8)"]
+falcon = ["falcon (>=1.4)"]
+flask = ["flask (>=0.11)", "blinker (>=1.1)"]
+httpx = ["httpx (>=0.16.0)"]
+pure_eval = ["pure-eval", "executing", "asttokens"]
+pyspark = ["pyspark (>=2.4.4)"]
+quart = ["quart (>=0.16.1)", "blinker (>=1.1)"]
+rq = ["rq (>=0.6)"]
+sanic = ["sanic (>=0.8)"]
+sqlalchemy = ["sqlalchemy (>=1.2)"]
+tornado = ["tornado (>=5)"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -580,6 +630,10 @@ charset-normalizer = [
     {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
     {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
 ]
+cli-tracker = [
+    {file = "cli_tracker-0.2.5-py3-none-any.whl", hash = "sha256:6b29128354870a1655cfcdff07f678a05413b6e18ee7c8f46e46fe690f41eff2"},
+    {file = "cli_tracker-0.2.5.tar.gz", hash = "sha256:a7945a408185816a9c8fe9e6b8d99ab0798eec8c6d6abc1d786256c6c18d2a00"},
+]
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
@@ -634,6 +688,10 @@ coverage = [
 coveralls = [
     {file = "coveralls-3.3.1-py2.py3-none-any.whl", hash = "sha256:f42015f31d386b351d4226389b387ae173207058832fbf5c8ec4b40e27b16026"},
     {file = "coveralls-3.3.1.tar.gz", hash = "sha256:b32a8bb5d2df585207c119d6c01567b81fba690c9c10a753bfe27a335bfc43ea"},
+]
+distro = [
+    {file = "distro-1.7.0-py3-none-any.whl", hash = "sha256:d596311d707e692c2160c37807f83e3820c5d539d5a83e87cfb6babd8ba3a06b"},
+    {file = "distro-1.7.0.tar.gz", hash = "sha256:151aeccf60c216402932b52e40ee477a939f8d58898927378a02abbe852c1c39"},
 ]
 docker = [
     {file = "docker-5.0.3-py2.py3-none-any.whl", hash = "sha256:7a79bb439e3df59d0a72621775d600bc8bc8b422d285824cb37103eab91d1ce0"},
@@ -812,6 +870,10 @@ requests-oauthlib = [
 rsa = [
     {file = "rsa-4.8-py3-none-any.whl", hash = "sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb"},
     {file = "rsa-4.8.tar.gz", hash = "sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17"},
+]
+sentry-sdk = [
+    {file = "sentry-sdk-1.6.0.tar.gz", hash = "sha256:b82ad57306d5546713f15d5d70daea0408cf7f998c7566db16e0e6257e51e561"},
+    {file = "sentry_sdk-1.6.0-py2.py3-none-any.whl", hash = "sha256:ddbd191b6f4e696b7845b4d87389898ae1207981faf114f968a57363aa6be03c"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/client/pyoxidizer.bzl
+++ b/client/pyoxidizer.bzl
@@ -41,6 +41,7 @@ def make_exe():
     exe.add_python_resources(exe.pip_install(["--no-deps", "docker"]))
     exe.add_python_resources(exe.pip_install(["kubernetes"]))
     exe.add_python_resources(exe.pip_install(["tabulate"]))
+    exe.add_python_resources(exe.pip_install(["cli-tracker"]))
     return exe
 
 def make_win_exe():
@@ -76,6 +77,7 @@ def make_win_exe():
     exe.add_python_resources(exe.pip_install(["kubernetes"]))
     exe.add_python_resources(exe.pip_install(["pywin32"]))
     exe.add_python_resources(exe.pip_install(["tabulate"]))
+    exe.add_python_resources(exe.pip_install(["cli-tracker"]))
     exe.windows_runtime_dlls_mode = "always"
     return exe
 

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 python = "^3.8"
 kubernetes = "^19.15.0"
 docker = "^5.0.3"
+cli-tracker = "0.2.5"
 tabulate = "^0.8.10"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Adds telemetry for cli usage. Data will be published on gefyra.dev when available.
To collect the data the cli_tracking dependency (by Blueshoe) is needed which depends on Sentry's SDK. 

ToDo:
- [x] check tests
- [x] add dependencies for pyoxidizer 