### PR TITLE
feat: add kubernetes notation for `--env-from` flag

### DIFF
--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -51,7 +51,7 @@ jobs:
   test:
     needs: build_operator
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -92,10 +92,16 @@ jobs:
         test $? -eq 1
         curl localhost:8000
         test $? -ne 0
+    - name: Run gefyra run with faulty env-from flag
+      working-directory: ./client
+      shell: bash --noprofile --norc -o pipefail {0}
+      run: |
+        poetry run coverage run -a -m gefyra run -i pyserver -N mypyserver -n default --expose 8000:8000 --env-from=noDeployment/hello-nginxdemo
+        test $? -eq 1
     - name: Run gefyra run with localhost port mapping
       working-directory: ./client
       run: |
-        poetry run coverage run -a -m gefyra run -i pyserver -N mypyserver -n default --expose 8000:8000
+        poetry run coverage run -a -m gefyra run -i pyserver -N mypyserver -n default --expose 8000:8000 --env-from=deployment/hello-nginxdemo
         test $? -eq 0
         curl localhost:8000
         test $? -eq 0

--- a/client/gefyra/api/run.py
+++ b/client/gefyra/api/run.py
@@ -12,14 +12,30 @@ from ..local.cargo import probe_wireguard_connection
 logger = logging.getLogger(__name__)
 
 
+def get_workload_type(workload_type_str: str):
+    POD = ["pod", "po", "pods"]
+    DEPLOYMENT = ["deploy", "deployment", "deployments"]
+    STATEFULSET = ["statefulset", "sts", "statefulsets"]
+    VALID_TYPES = POD + DEPLOYMENT + STATEFULSET
+
+    if workload_type_str not in VALID_TYPES:
+        raise RuntimeError(f"Unknown workload type {workload_type_str}")
+
+    if workload_type_str in POD:
+        return "pod"
+    elif workload_type_str in DEPLOYMENT:
+        return "deployment"
+    elif workload_type_str in STATEFULSET:
+        return "statefulset"
+
+
 def retrieve_pod_and_container(
     env_from: str, namespace: str, config: ClientConfiguration
 ) -> (str, str):
     container_name = ""
-    workload_type, workload_name = env_from.split("/")
+    workload_type, workload_name = env_from.split("/", 1)
 
-    if workload_type not in ["pod", "deployment", "statefulset"]:
-        raise RuntimeError(f"Unknown workload type {workload_type}")
+    workload_type = get_workload_type(workload_type)
 
     if "/" in workload_name:
         workload_name, container_name = workload_name.split("/")


### PR DESCRIPTION
`--env-from` flag now allows following notation:
pod/podname1
deployment/deployment1
statefulset/statefulset1
pod/podname1/container-name
statefulset/statefulset1/container-name
deployment/deployment1/container-name

Resolves #130