### PR TITLE
chore: update docker actions / use build caching

### DIFF
--- a/.github/workflows/docker-build-multiarch.yaml
+++ b/.github/workflows/docker-build-multiarch.yaml
@@ -21,13 +21,13 @@ jobs:
         uses: actions/checkout@v2
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to quay.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_ROBOT }}
@@ -37,7 +37,7 @@ jobs:
       #
       - name: Operator Image meta
         id: operator_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           flavor: |
             latest=false
@@ -47,17 +47,19 @@ jobs:
             type=raw,value=latest,enable=${{ !startsWith(github.ref, 'refs/tags/') }}
             type=raw,value={{tag}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: operator/
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.operator_meta.outputs.tags }}
+          cache-from: type=registry,ref=${{ steps.operator_meta.outputs.tags }}
+          cache-to: type=inline
       #
       # Gefyra Cargo
       #
       - name: Cargo Image meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         id: cargo_meta
         with:
           flavor: |
@@ -68,17 +70,19 @@ jobs:
             type=raw,value=latest,enable=${{ !startsWith(github.ref, 'refs/tags/') }}
             type=raw,value={{tag}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: cargo/
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.cargo_meta.outputs.tags }}
+          cache-from: type=registry,ref=${{ steps.cargo_meta.outputs.tags }}
+          cache-to: type=inline
       #
       # Gefyra Carrier
       #
       - name: Carrier Image meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         id: carrier_meta
         with:
           flavor: |
@@ -89,17 +93,19 @@ jobs:
             type=raw,value=latest,enable=${{ !startsWith(github.ref, 'refs/tags/') }}
             type=raw,value={{tag}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: carrier/
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.carrier_meta.outputs.tags }}
+          cache-from: type=registry,ref=${{ steps.carrier_meta.outputs.tags }}
+          cache-to: type=inline
       #
       # Gefyra Stowaway
       #
       - name: Stowaway Image meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         id: stowaway_meta
         with:
           flavor: |
@@ -110,9 +116,11 @@ jobs:
             type=raw,value=latest,enable=${{ !startsWith(github.ref, 'refs/tags/') }}
             type=raw,value={{tag}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: stowaway/
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.stowaway_meta.outputs.tags }}
+          cache-from: type=registry,ref=${{ steps.stowaway_meta.outputs.tags }}
+          cache-to: type=inline

--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   build_operator:
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.operator_meta.outputs.tags }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -89,7 +91,7 @@ jobs:
     - name: Run gefyra up
       working-directory: ./client
       run: |
-        poetry run coverage run -a -m gefyra up --operator quay.io/gefyra/operator:test-run-${{github.run_id}}
+        poetry run coverage run -a -m gefyra up --operator ${{ needs.build_operator.outputs.tag_name }}
     - name: Build a docker file
       working-directory: testing/images/
       run: |

--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -14,13 +14,13 @@ jobs:
         uses: actions/checkout@v2
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to quay.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_ROBOT }}
@@ -30,24 +30,26 @@ jobs:
       #
       - name: Operator Image meta
         id: operator_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           flavor: |
             latest=false
           images: |
             quay.io/gefyra/operator
           tags: |
-            type=raw,value=test-run-${{github.run_id}},enable=true
+            type=ref,event=pr,enable=true
           labels: |
             quay.expires-after=24h
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: operator/
           platforms: linux/amd64
           push: true
           tags: ${{ steps.operator_meta.outputs.tags }}
           labels: ${{ steps.operator_meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ steps.operator_meta.outputs.tags }}
+          cache-to: type=inline
   test:
     needs: build_operator
     runs-on: ubuntu-latest


### PR DESCRIPTION
Bumps Docker Github actions. 

Adds inline caching information to builds. Can be retrieved for the next build then. Close #145 