### PR TITLE
feat: add kubeconfig / context flag

### DIFF
--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -65,14 +65,17 @@ jobs:
         python-version: '3.x'
     - name: Install Poetry
       uses: snok/install-poetry@v1
-    - name: Set Gefyra to no tracking
+    - name: Set Gefyra tracking config / fake kubeconfig
       shell: bash
       run: |
         mkdir -p ~/.gefyra
+        mkdir -p ~/.kube
         cd ~/.gefyra
         touch config.ini
         echo "[telemetry]" >> config.ini
         echo "track = False" >> config.ini
+        cd ~/.kube
+        touch config
     - name: Pytest
       working-directory: ./client
       run: |
@@ -89,6 +92,22 @@ jobs:
     - name: Apply some workload
       run: |
         kubectl apply -f testing/workloads/hello.yaml
+    - name: Run gefyra check
+      working-directory: ./client
+      run: |
+        poetry run coverage run -a -m gefyra check
+    - name: Run gefyra up with invalid kubeconfig path
+      working-directory: ./client
+      shell: bash --noprofile --norc -o pipefail {0}
+      run: |
+        poetry run coverage run -a -m gefyra --kubeconfig=/there/is/no/config up
+        test $? -eq 1
+    - name: Run gefyra up with invalid context
+      working-directory: ./client
+      shell: bash --noprofile --norc -o pipefail {0}
+      run: |
+        poetry run coverage run -a -m gefyra --context=invalid-context up
+        test $? -eq 1
     - name: Run gefyra up
       working-directory: ./client
       run: |

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -239,21 +239,22 @@ def get_client_configuration(args) -> ClientConfiguration:
     if args.context:
         configuration_params["kube_context"] = args.context
 
-    if args.minikube and bool(args.endpoint):
-        raise RuntimeError("You cannot use --endpoint together with --minikube.")
+    if args.action == "up":
+        if args.minikube and bool(args.endpoint):
+            raise RuntimeError("You cannot use --endpoint together with --minikube.")
 
-    if args.minikube:
-        configuration_params.update(detect_minikube_config())
-    else:
-        if not args.endpoint:
-            # #138: Read in the --endpoint parameter from kubeconf
-            endpoint = get_connection_from_kubeconfig()
-            if endpoint:
-                logger.info(f"Setting --endpoint from kubeconfig {endpoint}")
+        if args.minikube:
+            configuration_params.update(detect_minikube_config())
         else:
-            endpoint = args.endpoint
+            if not args.endpoint:
+                # #138: Read in the --endpoint parameter from kubeconf
+                endpoint = get_connection_from_kubeconfig()
+                if endpoint:
+                    logger.info(f"Setting --endpoint from kubeconfig {endpoint}")
+            else:
+                endpoint = args.endpoint
 
-        configuration_params["cargo_endpoint"] = endpoint
+            configuration_params["cargo_endpoint"] = endpoint
 
     configuration = ClientConfiguration(**configuration_params)
 

--- a/client/gefyra/api/list.py
+++ b/client/gefyra/api/list.py
@@ -10,10 +10,10 @@ from .utils import stopwatch
 logger = logging.getLogger(__name__)
 
 
-def get_containers_and_print():
+def get_containers_and_print(config: default_configuration):
     from gefyra.api import list_containers
 
-    containers = list_containers()
+    containers = list_containers(config=config)
     print(
         tabulate(
             containers, headers=["NAME", "IP ADDRESS", "NAMESPACE"], tablefmt="plain"
@@ -21,10 +21,10 @@ def get_containers_and_print():
     )
 
 
-def get_bridges_and_print():
+def get_bridges_and_print(config: default_configuration):
     from gefyra.api import list_interceptrequests
 
-    ireqs = list_interceptrequests()
+    ireqs = list_interceptrequests(config=config)
     if ireqs:
         for ireq in ireqs:
             print(ireq)

--- a/client/gefyra/configuration.py
+++ b/client/gefyra/configuration.py
@@ -1,3 +1,4 @@
+from os import path
 import struct
 import socket
 import sys
@@ -131,6 +132,11 @@ class ClientConfiguration(object):
         self.CARGO_PROBE_TIMEOUT = 10  # in seconds
         self.CONTAINER_RUN_TIMEOUT = 10  # in seconds
         self.KUBE_CONFIG_FILE = kube_config_file
+        if self.KUBE_CONFIG_FILE:
+            if not path.isfile(path.expanduser(self.KUBE_CONFIG_FILE)):
+                raise RuntimeError(
+                    f"KUBE_CONFIG_FILE {self.KUBE_CONFIG_FILE} not found."
+                )
         self.KUBE_CONTEXT = kube_context
 
         self.WIREGUARD_MTU = wireguard_mtu or "1340"

--- a/client/gefyra/local/minikube.py
+++ b/client/gefyra/local/minikube.py
@@ -2,8 +2,6 @@ import json
 import logging
 from pathlib import Path
 
-from gefyra.configuration import ClientConfiguration
-
 logger = logging.getLogger("gefyra")
 
 MINIKUBE_CONFIG = "~/.minikube/profiles/minikube/config.json"
@@ -24,10 +22,9 @@ def _get_a_worker_ip(config: dict):
     raise RuntimeError("This Minikube cluster does not have a worker node.")
 
 
-def detect_minikube_config(args) -> ClientConfiguration:
+def detect_minikube_config() -> dict:
     """
     Read the config for a local Minikube cluster from its configuration file and set Gefyra accordingly
-    :param args: CLI args
     :return: a preped ClientConfiguration object
     """
     try:
@@ -58,14 +55,9 @@ def detect_minikube_config(args) -> ClientConfiguration:
         f"Minikube setup with driver '{driver}' network '{network_name}' and endpoint '{endpoint}'"
     )
 
-    configuration = ClientConfiguration(
-        network_name=network_name,
-        cargo_endpoint=f"{endpoint}:31820",
-        registry_url=args.registry,
-        operator_image_url=args.operator,
-        stowaway_image_url=args.stowaway,
-        cargo_image_url=args.cargo,
-        carrier_image_url=args.carrier,
-        kube_context="minikube",
-    )
-    return configuration
+    configuration_parameters = {
+        "network_name": network_name,
+        "cargo_endpoint": f"{endpoint}:31820",
+        "kube_context": "minikube",
+    }
+    return configuration_parameters

--- a/client/tests/test_up_args.py
+++ b/client/tests/test_up_args.py
@@ -1,5 +1,5 @@
 import pytest
-from gefyra.__main__ import up_parser, up_command
+from gefyra.__main__ import parser, get_client_configuration
 from gefyra.configuration import ClientConfiguration, __VERSION__
 
 
@@ -13,61 +13,61 @@ KUBE_CONFIG = "~/.kube/config"
 
 
 def test_parse_registry_a():
-    args = up_parser.parse_args(["--registry", REGISTRY_URL])
+    args = parser.parse_args(["up", "--registry", REGISTRY_URL])
     configuration = ClientConfiguration(registry_url=args.registry)
     assert configuration.REGISTRY_URL == REGISTRY_URL
 
 
 def test_parse_registry_b():
-    args = up_parser.parse_args(["--registry", "my-reg.io/gefyra/"])
+    args = parser.parse_args(["up", "--registry", "my-reg.io/gefyra/"])
     configuration = ClientConfiguration(registry_url=args.registry)
     assert configuration.REGISTRY_URL, REGISTRY_URL
 
-    args = up_parser.parse_args(["-r", "my-reg.io/gefyra/"])
+    args = parser.parse_args(["up", "-r", "my-reg.io/gefyra/"])
     configuration = ClientConfiguration(registry_url=args.registry)
     assert configuration.REGISTRY_URL == REGISTRY_URL
 
 
 def test_parse_no_registry():
-    args = up_parser.parse_args()
+    args = parser.parse_args(["up"])
     configuration = ClientConfiguration(registry_url=args.registry)
     assert configuration.REGISTRY_URL == QUAY_REGISTRY_URL
 
 
 def test_parse_no_stowaway_image():
-    args = up_parser.parse_args()
+    args = parser.parse_args(["up"])
     configuration = ClientConfiguration(stowaway_image_url=args.stowaway)
     assert configuration.STOWAWAY_IMAGE == f"quay.io/gefyra/stowaway:{__VERSION__}"
 
 
 def test_parse_no_carrier_image():
-    args = up_parser.parse_args()
+    args = parser.parse_args(["up"])
     configuration = ClientConfiguration(carrier_image_url=args.carrier)
     assert configuration.CARRIER_IMAGE == f"quay.io/gefyra/carrier:{__VERSION__}"
 
 
 def test_parse_no_operator_image():
-    args = up_parser.parse_args()
+    args = parser.parse_args(["up"])
     configuration = ClientConfiguration(operator_image_url=args.operator)
     assert configuration.OPERATOR_IMAGE == f"quay.io/gefyra/operator:{__VERSION__}"
 
 
 def test_parse_no_cargo_image():
-    args = up_parser.parse_args()
+    args = parser.parse_args(["up"])
     configuration = ClientConfiguration(cargo_image_url=args.cargo)
     assert configuration.CARGO_IMAGE == f"quay.io/gefyra/cargo:{__VERSION__}"
 
 
 def test_parse_stowaway_image():
-    args = up_parser.parse_args(["--stowaway", STOWAWAY_LATEST])
+    args = parser.parse_args(["up", "--stowaway", STOWAWAY_LATEST])
     configuration = ClientConfiguration(stowaway_image_url=args.stowaway)
     assert configuration.STOWAWAY_IMAGE == STOWAWAY_LATEST
 
-    args = up_parser.parse_args(["-s", STOWAWAY_LATEST])
+    args = parser.parse_args(["up", "-s", STOWAWAY_LATEST])
     configuration = ClientConfiguration(stowaway_image_url=args.stowaway)
     assert configuration.STOWAWAY_IMAGE == STOWAWAY_LATEST
 
-    args = up_parser.parse_args(["-s", STOWAWAY_LATEST, "-r", QUAY_REGISTRY_URL])
+    args = parser.parse_args(["up", "-s", STOWAWAY_LATEST, "-r", QUAY_REGISTRY_URL])
     configuration = ClientConfiguration(
         registry_url=args.registry, stowaway_image_url=args.stowaway
     )
@@ -75,15 +75,15 @@ def test_parse_stowaway_image():
 
 
 def test_parse_cargo_image():
-    args = up_parser.parse_args(["--cargo", CARGO_LATEST])
+    args = parser.parse_args(["up", "--cargo", CARGO_LATEST])
     configuration = ClientConfiguration(cargo_image_url=args.cargo)
     assert configuration.CARGO_IMAGE == CARGO_LATEST
 
-    args = up_parser.parse_args(["-a", CARGO_LATEST])
+    args = parser.parse_args(["up", "-a", CARGO_LATEST])
     configuration = ClientConfiguration(cargo_image_url=args.cargo)
     assert configuration.CARGO_IMAGE == CARGO_LATEST
 
-    args = up_parser.parse_args(["-a", CARGO_LATEST, "-r", QUAY_REGISTRY_URL])
+    args = parser.parse_args(["up", "-a", CARGO_LATEST, "-r", QUAY_REGISTRY_URL])
     configuration = ClientConfiguration(
         registry_url=args.registry, cargo_image_url=args.cargo
     )
@@ -91,15 +91,15 @@ def test_parse_cargo_image():
 
 
 def test_parse_operator_image():
-    args = up_parser.parse_args(["--operator", OPERATOR_LATEST])
+    args = parser.parse_args(["up", "--operator", OPERATOR_LATEST])
     configuration = ClientConfiguration(operator_image_url=args.operator)
     assert configuration.OPERATOR_IMAGE == OPERATOR_LATEST
 
-    args = up_parser.parse_args(["-o", OPERATOR_LATEST])
+    args = parser.parse_args(["up", "-o", OPERATOR_LATEST])
     configuration = ClientConfiguration(operator_image_url=args.operator)
     assert configuration.OPERATOR_IMAGE == OPERATOR_LATEST
 
-    args = up_parser.parse_args(["-o", OPERATOR_LATEST, "-r", QUAY_REGISTRY_URL])
+    args = parser.parse_args(["up", "-o", OPERATOR_LATEST, "-r", QUAY_REGISTRY_URL])
     configuration = ClientConfiguration(
         registry_url=args.registry, operator_image_url=args.operator
     )
@@ -107,15 +107,15 @@ def test_parse_operator_image():
 
 
 def test_parse_carrier_image():
-    args = up_parser.parse_args(["--carrier", CARRIER_LATEST])
+    args = parser.parse_args(["up", "--carrier", CARRIER_LATEST])
     configuration = ClientConfiguration(carrier_image_url=args.carrier)
     assert configuration.CARRIER_IMAGE == CARRIER_LATEST
 
-    args = up_parser.parse_args(["-c", CARRIER_LATEST])
+    args = parser.parse_args(["up", "-c", CARRIER_LATEST])
     configuration = ClientConfiguration(carrier_image_url=args.carrier)
     assert configuration.CARRIER_IMAGE == CARRIER_LATEST
 
-    args = up_parser.parse_args(["-c", CARRIER_LATEST, "-r", QUAY_REGISTRY_URL])
+    args = parser.parse_args(["up", "-c", CARRIER_LATEST, "-r", QUAY_REGISTRY_URL])
     configuration = ClientConfiguration(
         registry_url=args.registry, carrier_image_url=args.carrier
     )
@@ -123,7 +123,7 @@ def test_parse_carrier_image():
 
 
 def test_parse_combination_a():
-    args = up_parser.parse_args(["-c", CARRIER_LATEST])
+    args = parser.parse_args(["up", "-c", CARRIER_LATEST])
     configuration = ClientConfiguration(
         registry_url=args.registry,
         stowaway_image_url=args.stowaway,
@@ -137,7 +137,7 @@ def test_parse_combination_a():
 
 
 def test_parse_combination_b():
-    args = up_parser.parse_args(["-r", REGISTRY_URL])
+    args = parser.parse_args(["up", "-r", REGISTRY_URL])
     configuration = ClientConfiguration(
         registry_url=args.registry,
         stowaway_image_url=args.stowaway,
@@ -151,8 +151,8 @@ def test_parse_combination_b():
 
 
 def test_parse_combination_c():
-    args = up_parser.parse_args(
-        ["-r", REGISTRY_URL, "-c", "quay.io/gefyra/carrier:latest"]
+    args = parser.parse_args(
+        ["up", "-r", REGISTRY_URL, "-c", "quay.io/gefyra/carrier:latest"]
     )
     configuration = ClientConfiguration(
         registry_url=args.registry,
@@ -167,7 +167,7 @@ def test_parse_combination_c():
 
 
 def test_parse_endpoint():
-    args = up_parser.parse_args(["-e", "10.30.34.25:31820"])
+    args = parser.parse_args(["up", "-e", "10.30.34.25:31820"])
     configuration = ClientConfiguration(
         cargo_endpoint=args.endpoint,
         registry_url=args.registry,
@@ -181,22 +181,22 @@ def test_parse_endpoint():
 
 def test_parse_up_fct(monkeypatch):
     monkeypatch.setattr("gefyra.api.up", lambda config: True)
-    args = up_parser.parse_args(["-e", "10.30.34.25:31820"])
-    up_command(args)
+    args = parser.parse_args(["up", "-e", "10.30.34.25:31820"])
+    get_client_configuration(args)
 
 
 def test_parse_up_endpoint_and_minikube(monkeypatch):
     monkeypatch.setattr("gefyra.api.up", lambda config: True)
-    args = up_parser.parse_args(["-e", "10.30.34.25:31820", "--minikube"])
+    args = parser.parse_args(["up", "-e", "10.30.34.25:31820", "--minikube"])
     with pytest.raises(RuntimeError):
-        up_command(args)
+        get_client_configuration(args)
 
 
 def test_parse_up_minikube_not_started(monkeypatch):
     monkeypatch.setattr("gefyra.api.up", lambda config: True)
-    args = up_parser.parse_args(["--minikube"])
+    args = parser.parse_args(["up", "--minikube"])
     with pytest.raises(RuntimeError):
-        up_command(args)
+        get_client_configuration(args)
 
 
 def test_parse_up_kube_conf():


### PR DESCRIPTION
This PR adds `--kubeconfig` and `--context`  flags to the gefyra CLI.

We want to use this flags in the planned Docker Desktop extension.

Closes #151