### PR TITLE
Improved DX for gefyra bridge action

### DIFF
--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -168,18 +168,18 @@ jobs:
         working-directory: ./client
         shell: bash --noprofile --norc -o pipefail {0}
         run: |
-          poetry run coverage run -a -m gefyra bridge -N mypyserver -n default --deployment hello-nginxdemo-not --port 80:8000 --container-name hello-nginx -I mypybridge
+          poetry run coverage run -a -m gefyra bridge -N mypyserver -n default --target deployment/hello-nginxdemo-not/hello-nginx --port 80:8000
           test $? -eq 1
       - name: Run gefyra bridge with invalid container
         working-directory: ./client
         shell: bash --noprofile --norc -o pipefail {0}
         run: |
-          poetry run coverage run -a -m gefyra bridge -N mypyserver -n default --deployment hello-nginxdemo --port 80:8000 --container-name hello-nginx-not -I mypybridge
+          poetry run coverage run -a -m gefyra bridge -N mypyserver -n default --target deployment/hello-nginxdemo/hello-nginx-not --port 80:8000
           test $? -eq 1
       - name: Run gefyra bridge with deployment
         working-directory: ./client
         run: |
-          poetry run coverage run -a -m gefyra bridge -N mypyserver -n default --deployment hello-nginxdemo --port 80:8000 --container-name hello-nginx -I mypybridge
+          poetry run coverage run -a -m gefyra bridge -N mypyserver -n default --target deployment/hello-nginxdemo/hello-nginx --port 80:8000
       - name: Run gefyra status check containers and bridge
         working-directory: ./client
         shell: bash --noprofile --norc -o pipefail {0}
@@ -201,7 +201,7 @@ jobs:
         run: |
           k=$(kubectl get pods -n default -o=go-template='{{ (index .items 0).metadata.name  }}')
           echo $k
-          poetry run coverage run -a -m gefyra bridge -N mypyserver -n default --pod $k --port 80:8000 --container-name hello-nginx -I mypybridge
+          poetry run coverage run -a -m gefyra bridge -N mypyserver -n default --target pod/$k/hello-nginx --port 80:8000
 
       - name: "Run gefyra list --bridges"
         working-directory: ./client

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ gefyra run -i <image_name> -N <container_name> -n default
 ```
 2. Create a bridge:
 ```shell
-gefyra bridge -N <container_name> -n <k8s_namespace> --deployment <k8s_deployment> --container-name <k8s_deployment_container> -I <bridge_name>
+gefyra bridge -N <container_name> -n <k8s_namespace> --target deployment/<k8s_deployment>/<k8s_deployment_container>
 ```
 Explanation for placeholders:
 - `container_name` the name of the container you created in the previous step
@@ -178,7 +178,7 @@ Check out this workload running under: http://hello.127.0.0.1.nip.io:8080/
    `docker exec -it mypyserver bash`  
    `wget -O- hello-nginx` will print out the website of the cluster service _hello-nginx_ from within the cluster.
 6) Create a bridge in order to intercept the traffic to the cluster application with the one running locally:    
-`gefyra bridge -N mypyserver -n default --deployment hello-nginxdemo --port 80:8000 --container-name hello-nginx -I mypybridge`    
+`gefyra bridge -N mypyserver -n default --target deployment/hello-nginxdemo/hello-nginx --port 80:8000`    
 Check out the locally running server comes up under: http://hello.127.0.0.1.nip.io:8080/  
 7) List all running _bridges_:  
 `gefyra list --bridges`

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -171,8 +171,8 @@ bridge_parser.add_argument(
 bridge_parser.add_argument(
     "--target",
     help="Intercept the container given in the notation 'resource/name/container'. "
-         "Resource can be one of 'deployment', 'statefulset' or 'pod'. "
-         "E.g.: --target deployment/hello-nginx/nginx",
+    "Resource can be one of 'deployment', 'statefulset' or 'pod'. "
+    "E.g.: --target deployment/hello-nginx/nginx",
     required=False,
 )
 

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -149,9 +149,6 @@ bridge_parser.add_argument(
     "-N", "--name", help="The name of the container running in Gefyra", required=True
 )
 bridge_parser.add_argument(
-    "-I", "--bridge-name", help="The name of the bridge", required=False
-)
-bridge_parser.add_argument(
     "-p",
     "--port",
     help="Add port mapping in form of <container_port>:<host_port>",
@@ -326,7 +323,6 @@ def main():
                 args.name,
                 args.port,
                 namespace=args.namespace,
-                bridge_name=args.bridge_name,
                 handle_probes=not args.no_probe_handling,
                 config=configuration,
                 target=args.target,

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -149,12 +149,6 @@ bridge_parser.add_argument(
     "-N", "--name", help="The name of the container running in Gefyra", required=True
 )
 bridge_parser.add_argument(
-    "-C",
-    "--container-name",
-    help="The name for the locally running container",
-    required=True,
-)
-bridge_parser.add_argument(
     "-I", "--bridge-name", help="The name of the bridge", required=False
 )
 bridge_parser.add_argument(
@@ -177,14 +171,11 @@ bridge_parser.add_argument(
     help="Make Carrier to not handle probes during switch operation",
     default=False,
 )
-intercept_flags = [
-    {"name": "deployment"},
-    {"name": "statefulset"},
-    {"name": "pod"},
-    {"name": "container"},
-]
-for flag in intercept_flags:
-    bridge_parser.add_argument(f"--{flag['name']}")
+bridge_parser.add_argument(
+    "--target",
+    help="Intercept the container given in the notation 'resource/name/containername'. Can be deployment, statefulset or pod. E.g.: --target deployment/hello-nginx/nginx",
+    required=False,
+)
 
 unbridge_parser = action.add_parser("unbridge")
 unbridge_parser.add_argument("-N", "--name", help="The name of the bridge")
@@ -219,15 +210,6 @@ try:
     telemetry = CliTelemetry()
 except Exception:
     telemetry = False
-
-
-def get_intercept_kwargs(parser_args):
-    kwargs = {}
-    for flag in intercept_flags:
-        _f = flag["name"].replace("-", "_")
-        if getattr(parser_args, _f):
-            kwargs[_f] = getattr(parser_args, _f)
-    return kwargs
 
 
 def version(config, check: bool):
@@ -341,12 +323,11 @@ def main():
             bridge(
                 args.name,
                 args.port,
-                container_name=args.container_name,
                 namespace=args.namespace,
                 bridge_name=args.bridge_name,
                 handle_probes=not args.no_probe_handling,
                 config=configuration,
-                **get_intercept_kwargs(args),
+                target=args.target,
             )
         elif args.action == "unbridge":
             if args.name:

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -173,7 +173,9 @@ bridge_parser.add_argument(
 )
 bridge_parser.add_argument(
     "--target",
-    help="Intercept the container given in the notation 'resource/name/containername'. Can be deployment, statefulset or pod. E.g.: --target deployment/hello-nginx/nginx",
+    help="Intercept the container given in the notation 'resource/name/container'. "
+         "Resource can be one of 'deployment', 'statefulset' or 'pod'. "
+         "E.g.: --target deployment/hello-nginx/nginx",
     required=False,
 )
 

--- a/client/gefyra/api/bridge.py
+++ b/client/gefyra/api/bridge.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from time import sleep
 from typing import List, Dict
 

--- a/client/gefyra/api/bridge.py
+++ b/client/gefyra/api/bridge.py
@@ -56,14 +56,14 @@ def check_workloads(pods_to_intercept, workload_type, workload_name, container_n
 
 @stopwatch
 def bridge(
-        name: str,
-        ports: dict,
-        target: str,
-        namespace: str = "default",
-        sync_down_dirs: List[str] = None,
-        handle_probes: bool = True,
-        timeout: int = 0,
-        config=default_configuration,
+    name: str,
+    ports: dict,
+    target: str,
+    namespace: str = "default",
+    sync_down_dirs: List[str] = None,
+    handle_probes: bool = True,
+    timeout: int = 0,
+    config=default_configuration,
 ) -> bool:
     from docker.errors import NotFound
     from gefyra.local.utils import (
@@ -104,9 +104,7 @@ def bridge(
         config=config,
     )
 
-    ireq_base_name = (
-        f"{name}-to-{namespace}.{workload_type}.{workload_name}"
-    )
+    ireq_base_name = f"{name}-to-{namespace}.{workload_type}.{workload_name}"
 
     use_index = check_workloads(
         pods_to_intercept,

--- a/client/gefyra/api/bridge.py
+++ b/client/gefyra/api/bridge.py
@@ -60,7 +60,6 @@ def bridge(
         ports: dict,
         target: str,
         namespace: str = "default",
-        bridge_name: str = None,
         sync_down_dirs: List[str] = None,
         handle_probes: bool = True,
         timeout: int = 0,
@@ -105,12 +104,9 @@ def bridge(
         config=config,
     )
 
-    if not bridge_name:
-        ireq_base_name = (
-            f"{name}-to-{namespace}.{workload_type}.{workload_name}"
-        )
-    else:
-        ireq_base_name = bridge_name
+    ireq_base_name = (
+        f"{name}-to-{namespace}.{workload_type}.{workload_name}"
+    )
 
     use_index = check_workloads(
         pods_to_intercept,

--- a/client/tests/test_port_parser.py
+++ b/client/tests/test_port_parser.py
@@ -21,7 +21,7 @@ def test_ip_port_mapper():
 
 def test_port_mapper():
     args = bridge_parser.parse_args(
-        ["--port=8081:8080", "--port=9091:9090", "-C=test", "-N=random"]
+        ["--port=8081:8080", "--port=9091:9090", "-N=random"]
     )
     assert "9090" in args.port
     assert "8080" in args.port


### PR DESCRIPTION
Implements changes suggested in #137.
At the Kubernetes Community Days Munich @SteinRobert mentioned that this issue is waiting to be fixed, so here you go :-).

@Schille said "... automatically name bridges following this scheme: <namespace>/<pod>"
This doesn't work as Kubernetes resource names can't contain a slash. Therefore I replaced the slash with a dot.
I now removed the bridge name option completely as @Schille had the more convincing argument, but this decision is not mine to make.

Another improvement would be to automatically select the container if there is only a single one inside the pod.

This is only a draft. I am grateful for any criticism and feedback!

