### PR TITLE
feat(#210): add docker context handling

### DIFF
--- a/client/gefyra/configuration.py
+++ b/client/gefyra/configuration.py
@@ -161,9 +161,16 @@ class ClientConfiguration(object):
 
     def _init_docker(self):
         import docker
+        from docker.context import ContextAPI
 
         try:
-            self.DOCKER = docker.from_env()
+            ctx = ContextAPI.get_context()
+            if ctx.name != "default":
+                endpoint = ctx.endpoints["docker"]["Host"]
+                self.DOCKER = docker.DockerClient(base_url=endpoint)
+                logger.debug(f"Docker Context: {ctx.name}")
+            else:
+                self.DOCKER = docker.from_env()
         except docker.errors.DockerException as de:
             logger.fatal(f"Docker init error: {de}")
             raise docker.errors.DockerException(


### PR DESCRIPTION
Resolves #210. Tested `status` and `run`.

We now set the context to whatever the context API tells us is set. In case the default is set we continue to init the docker client `from_env()`. Otherwise the endpoint from the given context is considered to init the Docker client.
