### PR TITLE
refactor(#217): `--endpoint` flag improvements

### DIFF
--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -27,7 +27,7 @@ up_parser.add_argument(
     "-e",
     "--endpoint",
     dest="cargo_endpoint",
-    help="the Wireguard endpoint in the form <IP>:<Port> for Gefyra to connect to",
+    help="the Wireguard endpoint in the form <IP>:<Port> for Gefyra to connect to. <Port> defaults to 31820.",
     required=False,
 )
 up_parser.add_argument(
@@ -250,6 +250,20 @@ def telemetry_command(on, off):
         logger.info("Invalid flags. Please use either --off or --on.")
 
 
+def prepare_cargo_endpoint(endpoint: str):
+    delimiter_count = endpoint.count(":")
+    if delimiter_count == 0:
+        return f"{endpoint}:31820"
+    elif delimiter_count == 1:
+        if endpoint[-1] == ":":
+            return f"{endpoint}:31820"
+        return endpoint
+    else:
+        raise RuntimeError(
+            "Invalid endpoint format. Endpoint must be in format <IP>:<Port>."
+        )
+
+
 def get_client_configuration(args) -> ClientConfiguration:
     configuration_params = {}
 
@@ -269,7 +283,7 @@ def get_client_configuration(args) -> ClientConfiguration:
                 if endpoint:
                     logger.info(f"Setting --endpoint from kubeconfig {endpoint}")
             else:
-                endpoint = args.cargo_endpoint
+                endpoint = prepare_cargo_endpoint(args.cargo_endpoint)
 
             configuration_params["cargo_endpoint"] = endpoint
         for argument in vars(args):

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -284,18 +284,12 @@ def get_client_configuration(args) -> ClientConfiguration:
                 endpoint = get_connection_from_kubeconfig()
                 if endpoint:
                     logger.info(f"Setting host and port from kubeconfig {endpoint}")
-            else:
-                endpoint = prepare_cargo_endpoint(
-                    args.cargo_endpoint_host, args.cargo_endpoint_port
-                )
 
             configuration_params["cargo_endpoint"] = endpoint
         for argument in vars(args):
             if argument not in [
                 "action",
                 "debug",
-                "cargo_endpoint_host",
-                "cargo_endpoint_port",
                 "minikube",
             ]:
                 configuration_params[argument] = getattr(args, argument)

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -284,8 +284,8 @@ def get_client_configuration(args) -> ClientConfiguration:
                 endpoint = get_connection_from_kubeconfig()
                 if endpoint:
                     logger.info(f"Setting host and port from kubeconfig {endpoint}")
-
-            configuration_params["cargo_endpoint"] = endpoint
+                    configuration_params["cargo_endpoint_host"] = endpoint.split(":")[0]
+                    configuration_params["cargo_endpoint_port"] = endpoint.split(":")[1]
         for argument in vars(args):
             if argument not in [
                 "action",

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -35,6 +35,7 @@ up_parser.add_argument(
     dest="cargo_endpoint_port",
     help="Open UDP port of the K8S node to connect to. Default to 31820.",
     required=False,
+    default="31820",
 )
 up_parser.add_argument(
     "-M",
@@ -254,16 +255,6 @@ def telemetry_command(on, off):
         telemetry.on()
     else:
         logger.info("Invalid flags. Please use either --off or --on.")
-
-
-def prepare_cargo_endpoint(host: str, port: str):
-    if host and not port:
-        return f"{host}:31820"
-    if port and not host:
-        raise RuntimeError(f"Please provide a host for port {port}.")
-    if host and port and not port.isnumeric():
-        raise RuntimeError(f"Please provide an integer as port. {port} is not valid.")
-    return f"{host}:{port}"
 
 
 def get_client_configuration(args) -> ClientConfiguration:

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -295,7 +295,7 @@ def get_client_configuration(args) -> ClientConfiguration:
                 "action",
                 "debug",
                 "cargo_endpoint_host",
-                "cargo_endpoint_host",
+                "cargo_endpoint_port",
                 "minikube",
             ]:
                 configuration_params[argument] = getattr(args, argument)

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -24,6 +24,14 @@ parser.add_argument("-d", "--debug", action="store_true", help="add debug output
 
 up_parser = action.add_parser("up")
 up_parser.add_argument(
+    "-e",
+    "--endpoint",
+    dest="cargo_endpoint",
+    help="the Wireguard endpoint in the form <IP>:<Port> for Gefyra to connect to",
+    required=False,
+)
+up_parser.add_argument(
+    "-H",
     "--host",
     dest="cargo_endpoint_host",
     help="Hostname or IP of a K8s node for Gefyra to connect to."
@@ -31,6 +39,7 @@ up_parser.add_argument(
     required=False,
 )
 up_parser.add_argument(
+    "-p",
     "--port",
     dest="cargo_endpoint_port",
     help="Open UDP port of the K8S node to connect to. Default to 31820.",
@@ -261,6 +270,11 @@ def get_client_configuration(args) -> ClientConfiguration:
     configuration_params = {}
 
     if args.action == "up":
+        if args.cargo_endpoint:
+            logger.warning(
+                "`--endpoint`/`-e` has been removed. Please consider `--host` and `--port` instead."
+            )
+            exit(1)
         if args.minikube and bool(args.cargo_endpoint_host):
             raise RuntimeError("You cannot use --endpoint together with --minikube.")
 

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -296,6 +296,7 @@ def get_client_configuration(args) -> ClientConfiguration:
                 "action",
                 "debug",
                 "minikube",
+                "cargo_endpoint",
             ]:
                 configuration_params[argument] = getattr(args, argument)
 

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -256,7 +256,7 @@ def prepare_cargo_endpoint(endpoint: str):
         return f"{endpoint}:31820"
     elif delimiter_count == 1:
         if endpoint[-1] == ":":
-            return f"{endpoint}:31820"
+            return f"{endpoint}31820"
         return endpoint
     else:
         raise RuntimeError(

--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -261,7 +261,7 @@ def prepare_cargo_endpoint(host: str, port: str):
         return f"{host}:31820"
     if port and not host:
         raise RuntimeError(f"Please provide a host for port {port}.")
-    if host and port and not not port.isnumeric():
+    if host and port and not port.isnumeric():
         raise RuntimeError(f"Please provide an integer as port. {port} is not valid.")
     return f"{host}:{port}"
 

--- a/client/gefyra/configuration.py
+++ b/client/gefyra/configuration.py
@@ -47,7 +47,8 @@ class ClientConfiguration(object):
         self,
         docker_client=None,
         network_name: str = None,
-        cargo_endpoint: str = None,
+        cargo_endpoint_host: str = None,
+        cargo_endpoint_port: str = "31820",
         cargo_container_name: str = None,
         registry_url: str = None,
         operator_image_url: str = None,
@@ -94,10 +95,8 @@ class ClientConfiguration(object):
             logger.debug(f"Using Cargo image (other than default): {cargo_image_url}")
         if docker_client:
             self.DOCKER = docker_client
-        if cargo_endpoint:
-            if len(cargo_endpoint.split(":")) != 2:
-                raise Exception("Please provide the endpoint in the form <ip:port>")
-            self.CARGO_ENDPOINT = cargo_endpoint
+        if cargo_endpoint_host:
+            self.CARGO_ENDPOINT = f"{cargo_endpoint_host}:{cargo_endpoint_port}"
         else:
             if sys.platform in ["darwin", "win32"]:
                 # docker for mac/win publishes ports on a special internal ip
@@ -106,7 +105,7 @@ class ClientConfiguration(object):
                         "alpine", "getent hosts host.docker.internal", remove=True
                     )
                     _ip = _ip_output.decode("utf-8").split(" ")[0]
-                    self.CARGO_ENDPOINT = f"{_ip}:31820"
+                    self.CARGO_ENDPOINT = f"{_ip}:{cargo_endpoint_port}"
                 except Exception as e:
                     logger.error("Could not create a valid configuration: " + str(e))
             else:
@@ -121,7 +120,7 @@ class ClientConfiguration(object):
                         struct.pack("256s", "docker0".encode("utf-8")[:15]),
                     )[20:24]
                 )
-                self.CARGO_ENDPOINT = f"{_ip}:31820"
+                self.CARGO_ENDPOINT = f"{_ip}:{cargo_endpoint_port}"
         self.CARGO_CONTAINER_NAME = cargo_container_name or "gefyra-cargo"
         self.STOWAWAY_IP = "192.168.99.1"
         self.NETWORK_NAME = network_name or "gefyra"

--- a/client/gefyra/local/cargo.py
+++ b/client/gefyra/local/cargo.py
@@ -136,6 +136,6 @@ def probe_wireguard_connection(config: ClientConfiguration):
         raise RuntimeError(
             f"Gefyra could not successfully confirm the Wireguard connection working. Please make sure you "
             f"are using the --endpoint argument for remote clusters and that the Kubernetes NodePort "
-            f"{config.CARGO_ENDPOINT.split(':')[1]} can be reached from this machine. Please check your firewall "
+            f"{config.CARGO_ENDPOINT} can be reached from this machine. Please check your firewall "
             f"settings, too. If you are running a local Minikube cluster, please use the 'gefyra up --minikube' flag."
         )

--- a/client/gefyra/local/cargo.py
+++ b/client/gefyra/local/cargo.py
@@ -135,7 +135,7 @@ def probe_wireguard_connection(config: ClientConfiguration):
     else:
         raise RuntimeError(
             f"Gefyra could not successfully confirm the Wireguard connection working. Please make sure you "
-            f"are using the --endpoint argument for remote clusters and that {config.CARGO_ENDPOINT} can "
-            f"reach Kubernetes node port 31820 from this machine. Please check your firewall "
+            f"are using the --endpoint argument for remote clusters and that the Kubernetes NodePort "
+            f"{config.CARGO_ENDPOINT.split(':')[1]} can be reached from this machine. Please check your firewall "
             f"settings, too. If you are running a local Minikube cluster, please use the 'gefyra up --minikube' flag."
         )

--- a/client/gefyra/local/minikube.py
+++ b/client/gefyra/local/minikube.py
@@ -57,7 +57,8 @@ def detect_minikube_config() -> dict:
 
     configuration_parameters = {
         "network_name": network_name,
-        "cargo_endpoint": f"{endpoint}:31820",
+        "cargo_endpoint_host": endpoint,
+        "cargo_endpoint_port": "31820",
         "kube_context": "minikube",
     }
     return configuration_parameters

--- a/client/gefyra/local/utils.py
+++ b/client/gefyra/local/utils.py
@@ -259,13 +259,20 @@ class PortMappingParser(argparse.Action):
 
 class IpPortMappingParser(PortMappingParser):
     def parse_split(self, split):
+        def v(p: str):
+            if not p.isnumeric():
+                raise RuntimeError(
+                    f"Invalid port {p}. Please use integer numbers as port."
+                )
+            return p
+
         # port - port
         res = {}
         if len(split) == 2:
-            res[split[1]] = split[0]
+            res[v(split[1])] = v(split[0])
             return res
         elif len(split) == 3:
-            res[split[2]] = (split[0], split[1])
+            res[v(split[2])] = (split[0], v(split[1]))
             return res
         else:
             raise ValueError

--- a/client/tests/test_up_args.py
+++ b/client/tests/test_up_args.py
@@ -167,7 +167,7 @@ def test_parse_combination_c():
 
 
 def test_parse_endpoint():
-    args = parser.parse_args(["up", "-e", "10.30.34.25:31820"])
+    args = parser.parse_args(["up", "--host", "10.30.34.25"])
     configuration = ClientConfiguration(
         cargo_endpoint=args.cargo_endpoint,
         registry_url=args.registry_url,
@@ -181,13 +181,13 @@ def test_parse_endpoint():
 
 def test_parse_up_fct(monkeypatch):
     monkeypatch.setattr("gefyra.api.up", lambda config: True)
-    args = parser.parse_args(["up", "-e", "10.30.34.25:31820"])
+    args = parser.parse_args(["up", "--host", "10.30.34.25", "--port", "31820"])
     get_client_configuration(args)
 
 
 def test_parse_up_endpoint_and_minikube(monkeypatch):
     monkeypatch.setattr("gefyra.api.up", lambda config: True)
-    args = parser.parse_args(["up", "-e", "10.30.34.25:31820", "--minikube"])
+    args = parser.parse_args(["up", "--host", "10.30.34.25", "--minikube"])
     with pytest.raises(RuntimeError):
         get_client_configuration(args)
 

--- a/client/tests/test_up_args.py
+++ b/client/tests/test_up_args.py
@@ -168,7 +168,7 @@ def test_parse_combination_c():
 
 def test_parse_endpoint():
     args = parser.parse_args(["up", "--host", "10.30.34.25"])
-    configuration = ClientConfiguration(**get_client_configuration(args))
+    configuration = get_client_configuration(args)
     assert configuration.CARGO_ENDPOINT == "10.30.34.25:31820"
 
 

--- a/client/tests/test_up_args.py
+++ b/client/tests/test_up_args.py
@@ -168,14 +168,7 @@ def test_parse_combination_c():
 
 def test_parse_endpoint():
     args = parser.parse_args(["up", "--host", "10.30.34.25"])
-    configuration = ClientConfiguration(
-        cargo_endpoint=args.cargo_endpoint,
-        registry_url=args.registry_url,
-        stowaway_image_url=args.stowaway_image_url,
-        operator_image_url=args.operator_image_url,
-        cargo_image_url=args.cargo_image_url,
-        carrier_image_url=args.carrier_image_url,
-    )
+    configuration = ClientConfiguration(**get_client_configuration(args))
     assert configuration.CARGO_ENDPOINT == "10.30.34.25:31820"
 
 


### PR DESCRIPTION
- change error text when wireguard probe fails
- default endpoint port to 31820

Addresses stuff in #217 
Fix #239 