### PR TITLE
fix: add ipv4 forward on stowaway

### DIFF
--- a/stowaway/root/defaults/server.conf
+++ b/stowaway/root/defaults/server.conf
@@ -2,5 +2,6 @@
 Address = ${INTERFACE}.1
 ListenPort = 51820
 PrivateKey = $(cat /config/server/privatekey-server)
+PreUp = sysctl -w net.ipv4.ip_forward=1
 PostUp = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE


### PR DESCRIPTION
I have a problem when working with a remote cluster, where cargo doesn't has a connection to the internet or other services of the cluster. Cargo is already configured with the forward, adding it manually to stowaway fixed the connectivity issues for me.