### PR TITLE
fix: dependabot github actions yaml format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"
-    directory: ".github/workflows"
+    directory: "/"
     assignees:
       - "SteinRobert"
     schedule:


### PR DESCRIPTION
Signed-off-by: Robert Stein <robert@blueshoe.de>

FIx directory value for dependabot.