### PR TITLE
Add PodSecurity admission label to configure namespace as privileged

### DIFF
--- a/client/gefyra/cluster/manager.py
+++ b/client/gefyra/cluster/manager.py
@@ -86,7 +86,14 @@ def install_operator(config: ClientConfiguration, gefyra_network_subnet: str) ->
     tic = time.perf_counter()
     try:
         config.K8S_CORE_API.create_namespace(
-            body=V1Namespace(metadata=V1ObjectMeta(name=config.NAMESPACE))
+            body=V1Namespace(
+                metadata=V1ObjectMeta(
+                    name=config.NAMESPACE,
+                    labels={
+                        "pod-security.kubernetes.io/enforce": "privileged",
+                    },
+                )
+            )
         )
     except ApiException as e:
         if e.status == 409:


### PR DESCRIPTION
This is required to run stowaway on PodSecurity Admission-enabled clusters and since it is only a label, it won't do any harm on other clusters.

Signed-off-by: Mara Sophie Grosch <littlefox@lf-net.org>