### PR TITLE
fix: missing dependency in pyoxidizer build

### DIFF
--- a/client/gefyra/__main__.py
+++ b/client/gefyra/__main__.py
@@ -261,6 +261,7 @@ def version(config, check: bool):
                 f"You are using gefyra version {config.__VERSION__}; however, version {latest_release_version} is "
                 f"available."
             )
+    return True
 
 
 def telemetry_command(on, off):

--- a/client/pyoxidizer.bzl
+++ b/client/pyoxidizer.bzl
@@ -40,7 +40,7 @@ def make_exe():
     exe.add_python_resources(exe.read_package_root(CWD, ["gefyra"]))
     exe.add_python_resources(exe.pip_install(["--no-deps", "docker==6.0.1"]))
     # certifi from version 2022.06.15.1 does not work
-    exe.add_python_resources(exe.pip_install(["certifi==2022.06.15", "kubernetes", "packaging==21.3", "tabulate", "cli-tracker"]))
+    exe.add_python_resources(exe.pip_install(["chardet", "certifi==2022.06.15", "kubernetes", "packaging==21.3", "tabulate", "cli-tracker"]))
     return exe
 
 def make_win_exe():
@@ -74,7 +74,7 @@ def make_win_exe():
     exe.add_python_resources(exe.read_package_root(CWD, ["gefyra"]))
     exe.add_python_resources(exe.pip_install(["--no-deps", "docker==6.0.1"]))
     # certifi from version 2022.06.15.1 does not work
-    exe.add_python_resources(exe.pip_install(["certifi==2022.06.15", "pywin32", "kubernetes", "packaging==21.3", "tabulate", "cli-tracker"]))
+    exe.add_python_resources(exe.pip_install(["chardet", "certifi==2022.06.15", "pywin32", "kubernetes", "packaging==21.3", "tabulate", "cli-tracker"]))
     exe.windows_runtime_dlls_mode = "always"
     return exe
 


### PR DESCRIPTION
`chardet` is now missing in our builds. Add manually. See references:

https://github.com/psf/requests/pull/6261
https://github.com/psf/requests/issues/6331
https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/534


Signed-off-by: Robert Stein <robert@blueshoe.de>