### PR TITLE
fix(#330): use owner ref / field selector for env

### DIFF
--- a/client/gefyra/api/run.py
+++ b/client/gefyra/api/run.py
@@ -145,7 +145,7 @@ def run(
                 if len(k) > 1
             }
     except ApiException as e:
-        logger.error(f"Cannot copy environment from Pod: {e.reason}")
+        logger.error(f"Cannot copy environment from Pod: {e.reason} ({e.status}).")
         return False
     if env:
         env_overrides = {

--- a/client/gefyra/cluster/resources.py
+++ b/client/gefyra/cluster/resources.py
@@ -239,9 +239,6 @@ def get_pods_and_containers_for_workload(
             raise RuntimeError(NOT_FOUND_MSG)
         raise RuntimeError(API_EXCEPTION_MSG.format(e))
 
-    if not workload:
-        raise RuntimeError(f"Could not find {workload_type} - {name}.")
-
     # use workloads metadata uuid for owner references with field selector to get pods
     v1_label_selector = workload.spec.selector.match_labels
 

--- a/client/gefyra/cluster/resources.py
+++ b/client/gefyra/cluster/resources.py
@@ -222,17 +222,12 @@ def get_pods_and_containers_for_workload(
 
     if not workload:
         raise RuntimeError(f"Could not find {workload_type} - {name}.")
-    v1_label_selector = workload.spec.selector.match_labels
 
-    label_selector = ",".join(
-        [f"{key}={value}" for key, value in v1_label_selector.items()]
-    )
-
-    if not label_selector:
-        raise RuntimeError(f"No label selector set for {workload_type} - {name}.")
+    # use workloads metadata uuid for owner references with field selector to get pods
+    field_selector = f"metadata.ownerReferences.uid={workload.metadata.uid}"
 
     pods = config.K8S_CORE_API.list_namespaced_pod(
-        namespace=namespace, label_selector=label_selector
+        namespace=namespace, field_selector=field_selector
     )
     for pod in pods.items:
         result[pod.metadata.name] = [

--- a/client/gefyra/cluster/resources.py
+++ b/client/gefyra/cluster/resources.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Dict
+from typing import List, Dict, Union
 
 from kubernetes.client import (
     V1ServiceAccount,
@@ -16,6 +16,7 @@ from kubernetes.client import (
     V1EnvVar,
     V1DeploymentSpec,
     ApiException,
+    V1StatefulSet,
     V1Pod,
 )
 
@@ -198,6 +199,24 @@ def check_pod_valid_for_bridge(
     _check_pod_for_command(pod, container_name)
 
 
+def owner_reference_consistent(
+    pod: V1Pod,
+    workload: Union[V1Deployment, V1StatefulSet],
+    config: ClientConfiguration,
+) -> bool:
+    if workload.kind == "StatefulSet":
+        return pod.metadata.owner_references[0].uid == workload.metadata.uid
+    elif workload.kind == "Deployment":
+        replicaset_set = config.K8S_APP_API.read_namespaced_replica_set(
+            name=pod.metadata.owner_references[0].name,
+            namespace=pod.metadata.namespace,
+        )
+        return replicaset_set.metadata.owner_references[0].uid == workload.metadata.uid
+    raise RuntimeError(
+        f"Unknown workload type for owner reference check: {workload.kind}/{workload.metadata.name}."
+    )
+
+
 def get_pods_and_containers_for_workload(
     config: ClientConfiguration, name: str, namespace: str, workload_type: str
 ) -> Dict[str, List[str]]:
@@ -224,15 +243,23 @@ def get_pods_and_containers_for_workload(
         raise RuntimeError(f"Could not find {workload_type} - {name}.")
 
     # use workloads metadata uuid for owner references with field selector to get pods
-    field_selector = f"metadata.ownerReferences.uid={workload.metadata.uid}"
+    v1_label_selector = workload.spec.selector.match_labels
+
+    label_selector = ",".join(
+        [f"{key}={value}" for key, value in v1_label_selector.items()]
+    )
+
+    if not label_selector:
+        raise RuntimeError(f"No label selector set for {workload_type} - {name}.")
 
     pods = config.K8S_CORE_API.list_namespaced_pod(
-        namespace=namespace, field_selector=field_selector
+        namespace=namespace, label_selector=label_selector
     )
     for pod in pods.items:
-        result[pod.metadata.name] = [
-            container.name for container in pod.spec.containers
-        ]
+        if owner_reference_consistent(pod, workload, config):
+            result[pod.metadata.name] = [
+                container.name for container in pod.spec.containers
+            ]
 
     return result
 

--- a/client/gefyra/cluster/utils.py
+++ b/client/gefyra/cluster/utils.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 from collections.abc import Mapping
+from time import sleep
 
 from gefyra.configuration import ClientConfiguration
 
@@ -21,17 +22,35 @@ def decode_secret(u):
 def get_env_from_pod_container(
     config: ClientConfiguration, pod_name: str, namespace: str, container_name: str
 ):
+    from kubernetes.client import ApiException
     from kubernetes.stream import stream
 
-    resp = stream(
-        config.K8S_CORE_API.connect_get_namespaced_pod_exec,
-        pod_name,
-        namespace,
-        container=container_name,
-        command=["env"],
-        stderr=True,
-        stdin=False,
-        stdout=True,
-        tty=False,
+    retries = 3
+    counter = 0
+    interval = 3
+    while counter < retries:
+        try:
+            resp = stream(
+                config.K8S_CORE_API.connect_get_namespaced_pod_exec,
+                pod_name,
+                namespace,
+                container=container_name,
+                command=["env"],
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+            )
+            return resp
+        except ApiException as e:
+            if e.status == 500:
+                sleep(interval)
+                counter += 1
+                logger.debug(
+                    f"Failed to get env from pod {pod_name} in namespace {namespace} on try {counter}."
+                )
+            else:
+                raise e
+    raise RuntimeError(
+        f"Failed to get env from pod {pod_name} in namespace {namespace} after {retries} tries."
     )
-    return resp

--- a/client/gefyra/cluster/utils.py
+++ b/client/gefyra/cluster/utils.py
@@ -43,7 +43,8 @@ def get_env_from_pod_container(
             )
             return resp
         except ApiException as e:
-            if e.status == 500:
+            # e.status is 0 for some reason
+            if "500 Internal Server Error" in e.reason:
                 sleep(interval)
                 counter += 1
                 logger.debug(

--- a/client/gefyra/cluster/utils.py
+++ b/client/gefyra/cluster/utils.py
@@ -25,9 +25,9 @@ def get_env_from_pod_container(
     from kubernetes.client import ApiException
     from kubernetes.stream import stream
 
-    retries = 3
+    retries = 10
     counter = 0
-    interval = 3
+    interval = 1
     while counter < retries:
         try:
             resp = stream(

--- a/client/tests/e2e/base.py
+++ b/client/tests/e2e/base.py
@@ -291,16 +291,6 @@ class GefyraBaseTest:
                 return pod
         return None
 
-    def test_owner_reference_check(self):
-        config = ClientConfiguration()
-        wrong_pod = self._get_pod_startswith("gefyra-stowaway", "gefyra")
-        deployment = self.K8S_APP_API.read_namespaced_deployment(
-            name="hello-nginxdemo", namespace="default"
-        )
-        right_pod = self._get_pod_startswith("hello-nginxdemo", "default")
-        self.assertFalse(owner_reference_consistent(wrong_pod, deployment, config))
-        self.assertTrue(owner_reference_consistent(right_pod, deployment, config))
-
     def test_a_run_gefyra_version(self):
         res = version(config_package, False)
         self.assertTrue(res)
@@ -581,6 +571,19 @@ class GefyraBaseTest:
         self.assertIn(StatusSummary.UP, captured.out)
         self.assertIn('"containers": 1', captured.out)
         self.assertIn('"bridges": 1', captured.out)
+
+    def test_m_ownership_reference_check(self):
+        wrong_pod = self._get_pod_startswith("gefyra-stowaway", "gefyra")
+        deployment = self.K8S_APP_API.read_namespaced_deployment(
+            name="hello-nginxdemo", namespace="default"
+        )
+        right_pod = self._get_pod_startswith("hello-nginxdemo", "default")
+        self.assertFalse(
+            owner_reference_consistent(wrong_pod, deployment, default_configuration)
+        )
+        self.assertTrue(
+            owner_reference_consistent(right_pod, deployment, default_configuration)
+        )
 
     def test_n_run_gefyra_down(self):
         res = down(default_configuration)

--- a/client/tests/e2e/base.py
+++ b/client/tests/e2e/base.py
@@ -412,6 +412,7 @@ class GefyraBaseTest:
         self.assert_cargo_running()
         self.assert_gefyra_connected()
         run_params = self.default_run_params
+        self.caplog.set_level("DEBUG")
         run(**run_params)
         with self.assertRaises(RuntimeError) as rte:
             bridge_params = self.default_bridge_params


### PR DESCRIPTION
Fixes behaviour which might cause Gefyra to select a pod which actually does not belong to a deployment or statefulset. Instead of label_selectors it now works with a field_selector which leverages the owner reference / uuid of the deployment/ statefulset.

Signed-off-by: Robert Stein <robert@blueshoe.de>