### PR TITLE
fix(#361): split of paths for volume mounts

### DIFF
--- a/client/gefyra/local/utils.py
+++ b/client/gefyra/local/utils.py
@@ -42,7 +42,7 @@ def get_processed_paths(base_path: str, volumes: List[str]) -> Optional[List[str
         return None
     results = []
     for volume in volumes:
-        source, target = volume.split(":")
+        source, target = volume.rsplit(":", 1)
         if not os.path.isabs(source):
             source = os.path.realpath(os.path.join(base_path, source))
         results.append(f"{source}:{target}")

--- a/client/tests/unit/test_cli_utils.py
+++ b/client/tests/unit/test_cli_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import yaml
 
-from gefyra.local.utils import get_connection_from_kubeconfig
+from gefyra.local.utils import get_connection_from_kubeconfig, get_processed_paths
 from gefyra.api.utils import get_workload_type
 
 
@@ -61,3 +61,15 @@ def test_workload_type_util():
         get_workload_type("fake")
 
     assert "Unknown workload type fake" in str(rte.value)
+
+
+def test_path_cleaning_for_window():
+    # It's a bit weird since the test is executed on a Linux machine.
+    # That's why we have to use the os.getcwd() function.
+    volumes = [
+        "C:\\Users\\user\\Documents\\gefyra\\:/app",
+    ]
+    res = get_processed_paths(os.getcwd(), volumes)
+    assert res == [
+        os.getcwd() + "/C:\\Users\\user\\Documents\\gefyra\\:/app",
+    ]


### PR DESCRIPTION
Fix #361 