### PR TITLE
fix: owner_ship reference check

### DIFF
--- a/client/gefyra/cluster/resources.py
+++ b/client/gefyra/cluster/resources.py
@@ -207,10 +207,13 @@ def owner_reference_consistent(
     if workload.kind == "StatefulSet":
         return pod.metadata.owner_references[0].uid == workload.metadata.uid
     elif workload.kind == "Deployment":
-        replicaset_set = config.K8S_APP_API.read_namespaced_replica_set(
-            name=pod.metadata.owner_references[0].name,
-            namespace=pod.metadata.namespace,
-        )
+        try:
+            replicaset_set = config.K8S_APP_API.read_namespaced_replica_set(
+                name=pod.metadata.owner_references[0].name,
+                namespace=pod.metadata.namespace,
+            )
+        except ApiException:
+            return False
         return replicaset_set.metadata.owner_references[0].uid == workload.metadata.uid
     raise RuntimeError(
         f"Unknown workload type for owner reference check: {workload.kind}/{workload.metadata.name}."
@@ -257,7 +260,7 @@ def get_pods_and_containers_for_workload(
             result[pod.metadata.name] = [
                 container.name for container in pod.spec.containers
             ]
-
+    print(result)
     return result
 
 

--- a/client/gefyra/cluster/resources.py
+++ b/client/gefyra/cluster/resources.py
@@ -212,8 +212,9 @@ def owner_reference_consistent(
                 name=pod.metadata.owner_references[0].name,
                 namespace=pod.metadata.namespace,
             )
-        except ApiException:
-            return False
+        except ApiException as e:
+            if e.status == 404:
+                return False
         return replicaset_set.metadata.owner_references[0].uid == workload.metadata.uid
     raise RuntimeError(
         f"Unknown workload type for owner reference check: {workload.kind}/{workload.metadata.name}."
@@ -260,7 +261,6 @@ def get_pods_and_containers_for_workload(
             result[pod.metadata.name] = [
                 container.name for container in pod.spec.containers
             ]
-    print(result)
     return result
 
 


### PR DESCRIPTION
Ignore 404 for replicasets. If not found we simply return false, since the ownership is not referenced or valid..