### PR TITLE
fix: split var env vars containing '='

### DIFF
--- a/client/gefyra/api/run.py
+++ b/client/gefyra/api/run.py
@@ -4,7 +4,7 @@ import sys
 from threading import Thread
 
 from gefyra.configuration import default_configuration, ClientConfiguration
-from .utils import stopwatch, get_workload_type
+from .utils import generate_env_dict_from_strings, stopwatch, get_workload_type
 
 
 logger = logging.getLogger(__name__)
@@ -139,18 +139,13 @@ def run(
                 config, env_from_pod, namespace, env_from_container
             )
             logger.debug("ENV from pod/container is:\n" + raw_env)
-            env_dict = {
-                k[0]: k[1]
-                for k in [arg.split("=") for arg in raw_env.split("\n")]
-                if len(k) > 1
-            }
+            raw_env_vars = raw_env.split("\n")
+            env_dict = generate_env_dict_from_strings(raw_env_vars)
     except ApiException as e:
         logger.error(f"Cannot copy environment from Pod: {e.reason} ({e.status}).")
         return False
     if env:
-        env_overrides = {
-            k[0]: k[1] for k in [arg.split("=") for arg in env] if len(k) > 1
-        }
+        env_overrides = generate_env_dict_from_strings(env)
         env_dict.update(env_overrides)
 
     #

--- a/client/gefyra/api/utils.py
+++ b/client/gefyra/api/utils.py
@@ -23,12 +23,10 @@ def get_workload_type(workload_type_str: str):
         return "deployment"
     elif workload_type_str in STATEFULSET:
         return "statefulset"
-    
+
 
 def generate_env_dict_from_strings(env_vars: Iterable[str]) -> dict:
-    return {
-        k[0]: k[1] for k in [arg.split("=", 1) for arg in env_vars] if len(k) > 1
-    }
+    return {k[0]: k[1] for k in [arg.split("=", 1) for arg in env_vars] if len(k) > 1}
 
 
 def stopwatch(func):

--- a/client/gefyra/api/utils.py
+++ b/client/gefyra/api/utils.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from typing import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,12 @@ def get_workload_type(workload_type_str: str):
         return "deployment"
     elif workload_type_str in STATEFULSET:
         return "statefulset"
+    
+
+def generate_env_dict_from_strings(env_vars: Iterable[str]) -> dict:
+    return {
+        k[0]: k[1] for k in [arg.split("=", 1) for arg in env_vars] if len(k) > 1
+    }
 
 
 def stopwatch(func):

--- a/client/tests/unit/test_cli_utils.py
+++ b/client/tests/unit/test_cli_utils.py
@@ -81,15 +81,16 @@ def test_env_dict_creation():
         "APP=test-app",
         "TEST=tautology=tautology=tautology",
         "123NUM=blubb",
-        "VERSION=1.2.3"
+        "VERSION=1.2.3",
     ]
 
     res = generate_env_dict_from_strings(env_vars=env_vars)
-    TestCase().assertDictEqual({
-        "APP": "test-app",
-        "TEST": "tautology=tautology=tautology",
-        "123NUM": "blubb",
-        "VERSION": "1.2.3",
+    TestCase().assertDictEqual(
+        {
+            "APP": "test-app",
+            "TEST": "tautology=tautology=tautology",
+            "123NUM": "blubb",
+            "VERSION": "1.2.3",
         },
-        res
+        res,
     )

--- a/client/tests/unit/test_cli_utils.py
+++ b/client/tests/unit/test_cli_utils.py
@@ -1,11 +1,12 @@
 import os
+from unittest import TestCase
 import pytest
 from unittest.mock import patch
 
 import yaml
 
 from gefyra.local.utils import get_connection_from_kubeconfig, get_processed_paths
-from gefyra.api.utils import get_workload_type
+from gefyra.api.utils import generate_env_dict_from_strings, get_workload_type
 
 
 @patch("kubernetes.config.kube_config.KUBE_CONFIG_DEFAULT_LOCATION", "/tmp/kube.yaml")
@@ -73,3 +74,22 @@ def test_path_cleaning_for_window():
     assert res == [
         os.getcwd() + "/C:\\Users\\user\\Documents\\gefyra\\:/app",
     ]
+
+
+def test_env_dict_creation():
+    env_vars = [
+        "APP=test-app",
+        "TEST=tautology=tautology=tautology",
+        "123NUM=blubb",
+        "VERSION=1.2.3"
+    ]
+
+    res = generate_env_dict_from_strings(env_vars=env_vars)
+    TestCase().assertDictEqual({
+        "APP": "test-app",
+        "TEST": "tautology=tautology=tautology",
+        "123NUM": "blubb",
+        "VERSION": "1.2.3",
+        },
+        res
+    )


### PR DESCRIPTION
Adds fix to only split env string on first equal sign. Adds test for env string splitting.
Refactors env string splitting for env_from and env overrides.

Fixes #385 