### PR TITLE
Extend DNS domains to match k8s

### DIFF
--- a/client/gefyra/api/run.py
+++ b/client/gefyra/api/run.py
@@ -65,7 +65,7 @@ def run(
     else:
         ns_source = "--namespace argument"
 
-    dns_search = f"{namespace}.svc.cluster.local"
+    dns_search = f"{namespace}.svc.cluster.local svc.cluster.local cluster.local k8s"
     #
     # Confirm the wireguard connection working
     #


### PR DESCRIPTION
Add additional search domains to `/etc/resolv.conf` matching those found in natural k8s pod.
Issue raised for discussion in #513 