### PR TITLE
fix: storing original pod config

### DIFF
--- a/operator/gefyra/bridge/carrier/__init__.py
+++ b/operator/gefyra/bridge/carrier/__init__.py
@@ -232,17 +232,21 @@ class Carrier(AbstractGefyraBridgeProvider):
         :param ireq_object: the InterceptRequest object
         :return: None
         """
-        config = {
-            f"{self.namespace}-{self.pod}": json.dumps(
-                {
-                    "originalConfig": {
-                        "image": container.image,
-                        "command": container.command,
-                        "args": container.args,
+        config = [
+            {
+                "op": "add",
+                "path": f"/data/{self.namespace}-{self.pod}",
+                "value": json.dumps(
+                    {
+                        "originalConfig": {
+                            "image": container.image,
+                            "command": container.command,
+                            "args": container.args,
+                        }
                     }
-                }
-            )
-        }
+                ),
+            }
+        ]
         try:
             core_v1_api.patch_namespaced_config_map(
                 name=CARRIER_ORIGINAL_CONFIGMAP,

--- a/operator/gefyra/bridge/carrier/__init__.py
+++ b/operator/gefyra/bridge/carrier/__init__.py
@@ -232,20 +232,17 @@ class Carrier(AbstractGefyraBridgeProvider):
         :param ireq_object: the InterceptRequest object
         :return: None
         """
-        config = [
+        data = json.dumps(
             {
-                "op": "add",
-                "path": f"/data/{self.namespace}-{self.pod}",
-                "value": json.dumps(
-                    {
-                        "originalConfig": {
-                            "image": container.image,
-                            "command": container.command,
-                            "args": container.args,
-                        }
-                    }
-                ),
+                "originalConfig": {
+                    "image": container.image,
+                    "command": container.command,
+                    "args": container.args,
+                }
             }
+        )
+        config = [
+            {"op": "add", "path": f"/data/{self.namespace}-{self.pod}", "value": data}
         ]
         try:
             core_v1_api.patch_namespaced_config_map(
@@ -261,7 +258,9 @@ class Carrier(AbstractGefyraBridgeProvider):
                         metadata=k8s.client.V1ObjectMeta(
                             name=CARRIER_ORIGINAL_CONFIGMAP
                         ),
-                        data=config,
+                        data={
+                            f"{self.namespace}-{self.pod}": data,
+                        },
                     ),
                 )
             else:


### PR DESCRIPTION
This fixes issues with the unbridge command, which was hanging and not restoring the original pod config (since it wasn't stored in the first place).

Fixes #488 