### PR TITLE
chore: add `--pull` and `--platform` to run

### DIFF
--- a/client/gefyra/api/run.py
+++ b/client/gefyra/api/run.py
@@ -43,6 +43,8 @@ def run(
     namespace: str = "",
     env: Optional[List] = None,
     env_from: str = "",
+    pull: str = "missing",
+    platform: str = "linux/amd64",
 ) -> bool:
     from kubernetes.client import ApiException
     from docker.errors import APIError
@@ -116,6 +118,8 @@ def run(
             dns_search=dns_search,
             auto_remove=auto_remove,
             volumes=volumes,
+            pull=pull,
+            platform=platform,
         )
     except APIError as e:
         if e.status_code == 409:

--- a/client/gefyra/cli/run.py
+++ b/client/gefyra/cli/run.py
@@ -81,6 +81,20 @@ from gefyra.cli.utils import (
     "-i", "--image", help="The docker image to run in Gefyra", type=str, required=True
 )
 @click.option(
+    "--pull",
+    type=click.Choice(["always", "missing"], case_sensitive=False),
+    help="Define whether image should always be pulled",
+    required=False,
+    default="missing",
+)
+@click.option(
+    "--platform",
+    type=str,
+    help="Define platform for image pull. Default: linux/amd64",
+    required=False,
+    default="linux/amd64",
+)
+@click.option(
     "--connection-name", type=str, callback=check_connection_name, required=False
 )
 def run(
@@ -94,6 +108,8 @@ def run(
     command,
     name,
     image,
+    pull,
+    platform,
     connection_name,
 ):
     from gefyra import api
@@ -111,5 +127,7 @@ def run(
         auto_remove=auto_remove,
         volumes=volume,
         detach=detach,
+        pull=pull,
+        platform=platform,
         connection_name=connection_name,
     )

--- a/client/gefyra/local/bridge.py
+++ b/client/gefyra/local/bridge.py
@@ -148,7 +148,10 @@ def deploy_app_container(
 
     if pull == "always":
         console.info(f"Pulling image {image}...")
-        repo, tag = image.split(":")
+        if ":" in image:
+            repo, tag = image.split(":")
+        else:
+            repo, tag = image, "latest"
         config.DOCKER.images.pull(repository=repo, tag=tag, platform=platform)
         console.info(f"Pulling image {image} done.")
 

--- a/client/gefyra/local/bridge.py
+++ b/client/gefyra/local/bridge.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 
 from docker.models.containers import Container
 
+from gefyra.cli import console
 from gefyra.configuration import ClientConfiguration
 from gefyra.local.cargo import get_cargo_ip_from_netaddress
 from gefyra.types import GefyraLocalContainer
@@ -140,8 +141,16 @@ def deploy_app_container(
     env: Optional[Dict] = None,
     auto_remove: bool = False,
     dns_search: Optional[List[str]] = None,
+    pull: Optional[str] = "missing",
+    platform: Optional[str] = "linux/amd64",
 ) -> Container:
     import docker
+
+    if pull == "always":
+        console.info(f"Pulling image {image}...")
+        repo, tag = image.split(":")
+        config.DOCKER.images.pull(repository=repo, tag=tag, platform=platform)
+        console.info(f"Pulling image {image} done.")
 
     if not dns_search:
         dns_search = ["default"]

--- a/client/tests/e2e/base.py
+++ b/client/tests/e2e/base.py
@@ -1050,9 +1050,9 @@ class GefyraBaseTest:
                 "--command",
                 "python3 local.py",
                 "--connection-name",
+                CONNECTION_NAME,
                 "--pull",
                 "always",
-                CONNECTION_NAME,
             ],
             catch_exceptions=False,
         )

--- a/client/tests/e2e/base.py
+++ b/client/tests/e2e/base.py
@@ -1038,7 +1038,7 @@ class GefyraBaseTest:
             [
                 "run",
                 "--image",
-                "pyserver",
+                "quay.io/gefyra/pyserver",
                 "--name",
                 "mypyserver",
                 "--namespace",


### PR DESCRIPTION
Add `--pull` and `--platform` flags to run
command. With these the user can specifiy whether
images should always be pulled and if (always)
a specific platform should be used.