### PR TITLE
Add health-check for wireguard

### DIFF
--- a/stowaway/Dockerfile
+++ b/stowaway/Dockerfile
@@ -59,6 +59,7 @@ RUN \
     libqrencode \
     net-tools \
     openresolv \
+    python3 \
     perl && \
   echo "**** clean up ****" && \
   apk del --no-network build-dependencies && \
@@ -186,3 +187,4 @@ COPY /root /
 
 # ports and volumes
 EXPOSE 51820/udp
+EXPOSE 8000/tcp

--- a/stowaway/root/etc/s6-overlay/s6-rc.d/svc-wireguard-health-check/run
+++ b/stowaway/root/etc/s6-overlay/s6-rc.d/svc-wireguard-health-check/run
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv bash
+
+/etc/s6-overlay/s6-rc.d/svc-wireguard-health-check/wg-health-check.py --device=wg0 --port=8000

--- a/stowaway/root/etc/s6-overlay/s6-rc.d/svc-wireguard-health-check/type
+++ b/stowaway/root/etc/s6-overlay/s6-rc.d/svc-wireguard-health-check/type
@@ -1,0 +1,1 @@
+longrun

--- a/stowaway/root/etc/s6-overlay/s6-rc.d/svc-wireguard-health-check/wg-health-check.py
+++ b/stowaway/root/etc/s6-overlay/s6-rc.d/svc-wireguard-health-check/wg-health-check.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from optparse import OptionParser
+from os import popen
+
+class HealthCheck(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        if check(self.server.device):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"healthy\n")
+        else:
+            self.send_error(404)
+
+    def do_HEAD(self):
+        self.do_GET()
+
+def check(device):
+    return popen("ip link show %s up " % device).read() != ""
+
+def test(device):
+    if check(device):
+        print("%s up" % device)
+    else:
+        print("%s down" % device)
+
+def main(port, device):
+    server = HTTPServer(('', port), HealthCheck)
+    server.device = device
+    server.serve_forever()
+
+def opts():
+    parser = OptionParser(
+        description="HTTP server that sends 204 response when device is up.")
+    parser.add_option("-d", "--device", dest="device", default="wg0",
+                      help="device name to check (default wg0)")
+    parser.add_option("-p", "--port", dest="port", default=8080, type="int",
+                      help="port on which to listen (default 8080)")
+    parser.add_option("-t", "--test", action="store_true", dest="test", default=False,
+                      help="show status and exit")
+    return parser.parse_args()[0]
+
+if __name__ == "__main__":
+    options = opts()
+    if options.test:
+        test(options.device)
+    else:
+        main(options.port, options.device)


### PR DESCRIPTION
Note:
The actual health-check test requires tweaking: test only passes after gefyra-con-create; that is when wg0 device comes up for first time:
```
    return popen("ip link show %s up " % device).read() != ""
```