### PR TITLE
chore: remove mac minikube test

### DIFF
--- a/.github/workflows/python-tester.yaml
+++ b/.github/workflows/python-tester.yaml
@@ -217,9 +217,6 @@ jobs:
           - os: ubuntu-latest
             driver: ''
             kubectl_os: linux
-          - os: macos-13
-            driver: virtualbox
-            kubectl_os: darwin
     needs:
       - build_operator
       - build_cargo


### PR DESCRIPTION
Minikube in Github Actions is just too flaky. We tried several measure to reduce the flakiness, but never got rid of it.