### PR TITLE
fix: set default Wireguard MTU to 1340

### DIFF
--- a/.github/workflows/python-linter.yaml
+++ b/.github/workflows/python-linter.yaml
@@ -30,3 +30,9 @@ jobs:
         poetry install
         poetry run black . --check
         poetry run flake8 --config ../setup.cfg
+    - name: Run MyPy client
+      working-directory: client/
+      run: |
+        poetry install
+        poetry run mypy gefyra
+      

--- a/client/gefyra/api/clients.py
+++ b/client/gefyra/api/clients.py
@@ -108,7 +108,7 @@ def write_client_file(
         kube_config_file=kubeconfig,
         kube_context=kubecontext,
         registry=registry,
-        wireguard_mtu=wireguard_mtu,
+        wireguard_mtu=str(wireguard_mtu) if wireguard_mtu else None,
     )
     client = get_client(
         client_id, kubeconfig=config.KUBE_CONFIG_FILE, kubecontext=config.KUBE_CONTEXT

--- a/client/gefyra/api/connect.py
+++ b/client/gefyra/api/connect.py
@@ -43,7 +43,7 @@ def connect(  # noqa: C901
     connection_name: str,
     client_config: Optional[IO],
     minikube_profile: Optional[str] = None,
-    mtu: Optional[int] = None,
+    mtu: Optional[int] = 1340,
     probe_timeout: int = 60,
 ) -> bool:
     import kubernetes
@@ -97,7 +97,7 @@ def connect(  # noqa: C901
             cargo_endpoint_host=gclient_conf.gefyra_server.split(":")[0],
             cargo_endpoint_port=gclient_conf.gefyra_server.split(":")[1],
             cargo_container_name=f"gefyra-cargo-{connection_name}",
-            wireguard_mtu=gclient_conf.wireguard_mtu or mtu,
+            wireguard_mtu=gclient_conf.wireguard_mtu or (str(mtu) if mtu else None),
         )
 
         gclient = handle_get_gefyraclient(config, gclient_conf.client_id)

--- a/client/gefyra/api/connect.py
+++ b/client/gefyra/api/connect.py
@@ -52,7 +52,7 @@ def connect(  # noqa: C901
     cargo_container = None
     # if this connection already exists, just restore it
     if connection_name in [conns.name for conns in list_connections()]:
-        logger.debug(f"Restoring exinsting connection {connection_name}")
+        logger.debug(f"Restoring existing connection {connection_name}")
         config = ClientConfiguration(connection_name=connection_name)
         cargo_container = config.DOCKER.containers.get(config.CARGO_CONTAINER_NAME)
         client = get_client(config.CLIENT_ID, connection_name=config.CONNECTION_NAME)

--- a/client/gefyra/cli/clients.py
+++ b/client/gefyra/cli/clients.py
@@ -125,6 +125,7 @@ def inspect_client(ctx, client_id):
     "--mtu",
     help="The MTU for the Wireguard interface",
     type=int,
+    default=1340,
 )
 @click.pass_context
 @standard_error_handler

--- a/client/gefyra/cli/connections.py
+++ b/client/gefyra/cli/connections.py
@@ -89,6 +89,7 @@ def connections(ctx):
     "--mtu",
     help="The MTU for the Wireguard interface",
     type=int,
+    default=1340,
 )
 @standard_error_handler
 def connect_client(

--- a/client/gefyra/cli/updown.py
+++ b/client/gefyra/cli/updown.py
@@ -21,7 +21,7 @@ def _check_and_install(
     preset: Optional[str] = None,
     bar=None,
     registry: Optional[str] = None,
-    mtu: Optional[int] = None,
+    mtu: Optional[str] = None,
 ) -> bool:
     status = api.status(connection_name=connection_name)
 
@@ -80,7 +80,7 @@ def cluster_up(
     minikube: Optional[str] = None,
     preset: Optional[str] = None,
     registry: Optional[str] = None,
-    mtu: Optional[int] = None,
+    mtu: Optional[int] = 1340,
 ):
     from alive_progress import alive_bar
     from gefyra.exceptions import GefyraClientAlreadyExists, ClientConfigurationError
@@ -102,7 +102,7 @@ def cluster_up(
         kube_config_file=kubeconfig,
         kube_context=kubecontext,
         registry=registry,
-        wireguard_mtu=mtu,
+        wireguard_mtu=str(mtu) if mtu else None,
     )
     with alive_bar(
         4,

--- a/client/gefyra/cli/updown.py
+++ b/client/gefyra/cli/updown.py
@@ -71,6 +71,7 @@ def _check_and_install(
     help="Set the MTU for the Gefyra network",
     type=int,
     required=False,
+    default=1340,
 )
 @pass_context
 @standard_error_handler

--- a/client/gefyra/configuration.py
+++ b/client/gefyra/configuration.py
@@ -60,14 +60,14 @@ class ClientConfiguration(object):
         cargo_endpoint_host: str = "",
         cargo_endpoint_port: str = "31820",
         cargo_container_name: str = "",
-        registry: str = "",
+        registry: Optional[str] = "",
         operator_image_url: str = "",
         stowaway_image_url: str = "",
         carrier_image_url: str = "",
         cargo_image_url: str = "",
         kube_config_file: Optional[Path] = None,
         kube_context: Optional[str] = None,
-        wireguard_mtu: str = "1340",
+        wireguard_mtu: Optional[str] = None,
         client_id: str = "",
         gefyra_config_root: Optional[Union[str, Path]] = None,
         ignore_connection: bool = False,  # work with kubeconfig not connection
@@ -150,7 +150,10 @@ class ClientConfiguration(object):
         if kube_context:
             self.KUBE_CONTEXT = kube_context
 
-        self.WIREGUARD_MTU = wireguard_mtu
+        if not wireguard_mtu:
+            self.WIREGUARD_MTU = "1340"
+        else:
+            self.WIREGUARD_MTU = wireguard_mtu
         if not gefyra_config_root:
             self.GEFYRA_LOCATION = Path.home().joinpath(".gefyra")
         else:

--- a/client/gefyra/types.py
+++ b/client/gefyra/types.py
@@ -27,7 +27,7 @@ class GefyraClientConfig:
     ca_crt: str
     gefyra_server: str
     registry: Optional[str] = None
-    wireguard_mtu: Optional[str] = 1340
+    wireguard_mtu: Optional[str] = "1340"
 
     @property
     def json(self):

--- a/client/gefyra/types.py
+++ b/client/gefyra/types.py
@@ -26,8 +26,8 @@ class GefyraClientConfig:
     namespace: str
     ca_crt: str
     gefyra_server: str
-    registry: Optional[str]
-    wireguard_mtu: Optional[str]
+    registry: Optional[str] = None
+    wireguard_mtu: Optional[str] = 1340
 
     @property
     def json(self):

--- a/client/gefyra/types.py
+++ b/client/gefyra/types.py
@@ -164,7 +164,7 @@ class GefyraClient:
         gefyra_server: str,
         k8s_server: str = "",
         registry: Optional[str] = None,
-        wireguard_mtu: Optional[int] = None,
+        wireguard_mtu: Optional[int] = 1340,
     ) -> GefyraClientConfig:
         if not bool(self.service_account):
             self.update()
@@ -178,7 +178,8 @@ class GefyraClient:
                 ca_crt=self.service_account["ca.crt"],
                 gefyra_server=gefyra_server,
                 registry=registry,
-                wireguard_mtu=str(wireguard_mtu),
+                # if somehow the mtu is not given make sure to have null as json value
+                wireguard_mtu=str(wireguard_mtu) if wireguard_mtu else None,
             )
         else:
             raise ClientConfigurationError(

--- a/client/tests/unit/test_client_config.py
+++ b/client/tests/unit/test_client_config.py
@@ -1,0 +1,30 @@
+import json
+from gefyra.types import GefyraClientConfig
+
+
+def test_read_client_config():
+    payload = {
+        "client_id": "client-a",
+        "kubernetes_server": "https://gefyra.dev",
+        "provider": "stowaway",
+        "token": "some-token",
+        "namespace": "my_ms",
+        "ca_crt": "ca_cert",
+        "gefyra_server": "https://gefyra.dev",
+        "registry": "https://quay.io",
+        "wireguard_mtu": 1320,
+    }
+    GefyraClientConfig.from_json_str(json.dumps(payload))
+
+
+def test_read_client_config_optionals_missing():
+    payload = {
+        "client_id": "client-a",
+        "kubernetes_server": "https://gefyra.dev",
+        "provider": "stowaway",
+        "token": "some-token",
+        "namespace": "my_ms",
+        "ca_crt": "ca_cert",
+        "gefyra_server": "https://gefyra.dev",
+    }
+    GefyraClientConfig.from_json_str(json.dumps(payload))

--- a/client/tests/unit/test_client_file_manipulations.py
+++ b/client/tests/unit/test_client_file_manipulations.py
@@ -59,7 +59,37 @@ def test_a_write_client_file(operator: AClusterManager):
     assert client_file_json["wireguard_mtu"] == "1340"
 
 
-def test_a_write_client_file_with_registry_and_mtu(operator: AClusterManager):
+def test_b_write_client_file_without_registry_and_mtu(operator: AClusterManager):
+    k3d = operator
+
+    client_a: GefyraClient = k3d.kubectl(
+        ["-n", "gefyra", "get", "gefyraclients.gefyra.dev", "client-a"]
+    )
+
+    assert client_a["state"] is not None
+
+    k3d.wait(
+        "gefyraclients.gefyra.dev/client-a",
+        "jsonpath=.state=ACTIVE",
+        namespace="gefyra",
+        timeout=20,
+    )
+
+    client_file_str = write_client_file(
+        client_id="client-a",
+        host="localhost",
+        port="31820",
+        kubeconfig=k3d.kubeconfig,
+        kubecontext=k3d.context,
+    )
+
+    client_file_json = json.loads(client_file_str)
+
+    assert client_file_json["wireguard_mtu"] is None
+    assert client_file_json["registry"] is None
+
+
+def test_c_write_client_file_with_registry_and_mtu(operator: AClusterManager):
     k3d = operator
 
     client_a: GefyraClient = k3d.kubectl(
@@ -86,8 +116,6 @@ def test_a_write_client_file_with_registry_and_mtu(operator: AClusterManager):
     )
 
     client_file_json = json.loads(client_file_str)
-
-    print(client_file_json)
 
     assert client_file_json["wireguard_mtu"] == "570"
     assert client_file_json["registry"] == "kuchen.io/gefyra"

--- a/client/tests/unit/test_client_file_manipulations.py
+++ b/client/tests/unit/test_client_file_manipulations.py
@@ -85,7 +85,7 @@ def test_b_write_client_file_without_registry_and_mtu(operator: AClusterManager)
 
     client_file_json = json.loads(client_file_str)
 
-    assert client_file_json["wireguard_mtu"] is None
+    assert client_file_json["wireguard_mtu"] == "1340"
     assert client_file_json["registry"] is None
 
 


### PR DESCRIPTION
- Added default MTU of 1340 to CLI commands for clients, connections, and up/down
- Updated client configuration to handle MTU setting more robustly
- Fixed a typo in an existing log message