### PR TITLE
feat(GO-1026): allow passing arbitrary container engine args to gefyra run

### DIFF
--- a/client/gefyra/api/run.py
+++ b/client/gefyra/api/run.py
@@ -116,6 +116,7 @@ def run(
     security_opts: Optional[List[str]] = None,
     user: Optional[str] = None,
     privileged: Optional[bool] = None,
+    extra_container_args: Optional[Dict] = None,
 ) -> bool:
     from kubernetes.client import ApiException
     from docker.errors import APIError
@@ -216,6 +217,7 @@ def run(
             security_opts=security_opts,
             user=user,
             privileged=privileged,
+            extra_container_args=extra_container_args,
         )
     except APIError as e:
         if e.status_code == 409:

--- a/client/gefyra/cli/run.py
+++ b/client/gefyra/cli/run.py
@@ -1,15 +1,23 @@
 import ast
+import warnings
+
 import click
 from gefyra.cli.utils import (
     OptionEatAll,
     check_connection_name,
     parse_env,
+    parse_extra_container_args,
     parse_ip_port_map,
     parse_workload,
 )
 
 
-@click.command()
+@click.command(
+    context_settings=dict(
+        ignore_unknown_options=True,
+        allow_extra_args=True,
+    ),
+)
 @click.option(
     "-d",
     "--detach",
@@ -54,13 +62,13 @@ from gefyra.cli.utils import (
 )
 @click.option(
     "--cpu",
-    help="CPU limit for the container (e.g. '500m' or '2')",
+    help="[Deprecated: use -- --cpu-quota <value> instead] CPU limit for the container (e.g. '500m' or '2')",
     type=str,
     required=False,
 )
 @click.option(
     "--memory",
-    help="Memory limit for the container (e.g. '512Mi', '1Gi', or '1g')",
+    help="[Deprecated: use -- --mem-limit <value> instead] Memory limit for the container (e.g. '512Mi', '1Gi', or '1g')",
     type=str,
     required=False,
 )
@@ -143,7 +151,9 @@ from gefyra.cli.utils import (
     is_flag=True,
     default=False,
 )
+@click.pass_context
 def run(
+    ctx,
     detach,
     auto_remove,
     expose,
@@ -165,7 +175,37 @@ def run(
     security_opt,
     privileged,
 ):
+    """Run a container in Gefyra.
+
+    \b
+    Any additional container engine arguments can be passed after the known
+    options.  They are forwarded directly to the Docker/Podman API.
+    Use the docker-py parameter names with '--' prefix and '-' separators:
+
+    \b
+      gefyra run -i myimage -N myname -- --cpu-shares 512 --mem-reservation 256m
+      gefyra run -i myimage -N myname -- --cpu-period 100000 --cpu-quota 50000
+
+    \b
+    See https://docker-py.readthedocs.io/en/stable/containers.html for the
+    full list of supported parameters.
+    """
     from gefyra import api
+
+    if cpu:
+        warnings.warn(
+            "--cpu is deprecated; pass the equivalent docker-py argument instead, "
+            "e.g.: -- --cpu-quota <value>",
+            FutureWarning,
+            stacklevel=1,
+        )
+    if memory:
+        warnings.warn(
+            "--memory is deprecated; pass the equivalent docker-py argument instead, "
+            "e.g.: -- --mem-limit <value>",
+            FutureWarning,
+            stacklevel=1,
+        )
 
     if command:
         command = ast.literal_eval(command)[0]
@@ -178,6 +218,9 @@ def run(
         raise click.UsageError(
             "Option conflict: --cpu and --cpu-from cannot be used together. Please specify only one."
         )
+
+    # Parse extra container engine args from ctx.args
+    extra_container_args = parse_extra_container_args(ctx.args) if ctx.args else None
 
     security_opt = list(security_opt)
     result = api.run(
@@ -201,6 +244,7 @@ def run(
         security_opts=security_opt,
         privileged=privileged,
         connection_name=connection_name,
+        extra_container_args=extra_container_args,
     )
     if not result:
         exit(1)

--- a/client/gefyra/cli/run.py
+++ b/client/gefyra/cli/run.py
@@ -223,28 +223,31 @@ def run(
     extra_container_args = parse_extra_container_args(ctx.args) if ctx.args else None
 
     security_opt = list(security_opt)
-    result = api.run(
-        image=image,
-        name=name,
-        command=command,
-        namespace=namespace,
-        env_from=env_from,
-        cpu_from=cpu_from,
-        memory_from=memory_from,
-        cpu=cpu,
-        memory=memory,
-        user=user,
-        env=env,
-        ports=expose,
-        auto_remove=auto_remove,
-        volumes=volume,
-        detach=detach,
-        pull=pull,
-        platform=platform,
-        security_opts=security_opt,
-        privileged=privileged,
-        connection_name=connection_name,
-        extra_container_args=extra_container_args,
-    )
+    try:
+        result = api.run(
+            image=image,
+            name=name,
+            command=command,
+            namespace=namespace,
+            env_from=env_from,
+            cpu_from=cpu_from,
+            memory_from=memory_from,
+            cpu=cpu,
+            memory=memory,
+            user=user,
+            env=env,
+            ports=expose,
+            auto_remove=auto_remove,
+            volumes=volume,
+            detach=detach,
+            pull=pull,
+            platform=platform,
+            security_opts=security_opt,
+            privileged=privileged,
+            connection_name=connection_name,
+            extra_container_args=extra_container_args,
+        )
+    except ValueError as e:
+        raise click.UsageError(str(e)) from e
     if not result:
         exit(1)

--- a/client/gefyra/cli/run.py
+++ b/client/gefyra/cli/run.py
@@ -62,13 +62,23 @@ from gefyra.cli.utils import (
 )
 @click.option(
     "--cpu",
-    help="[Deprecated: use -- --cpu-quota <value> instead] CPU limit for the container (e.g. '500m' or '2')",
+    help=(
+        "[Deprecated: pass docker/podman args after '--' instead, e.g."
+        " `-- --cpu-period 100000 --cpu-quota 50000` for 0.5 CPU. Note: raw"
+        " microseconds, k8s-style notation is not supported by the engine]"
+        " CPU limit for the container (e.g. '500m' or '2')"
+    ),
     type=str,
     required=False,
 )
 @click.option(
     "--memory",
-    help="[Deprecated: use -- --mem-limit <value> instead] Memory limit for the container (e.g. '512Mi', '1Gi', or '1g')",
+    help=(
+        "[Deprecated: pass docker/podman args after '--' instead, e.g."
+        " `-- --memory 512m`. Note: the engine accepts suffixes 'b/k/m/g',"
+        " not k8s-style 'Mi'/'Gi'] Memory limit for the container (e.g."
+        " '512Mi', '1Gi', or '1g')"
+    ),
     type=str,
     required=False,
 )
@@ -194,15 +204,18 @@ def run(
 
     if cpu:
         warnings.warn(
-            "--cpu is deprecated; pass the equivalent docker-py argument instead, "
-            "e.g.: -- --cpu-quota <value>",
+            "--cpu is deprecated; pass docker/podman args after '--' instead, "
+            "e.g. `-- --cpu-period 100000 --cpu-quota 50000` for 0.5 CPU "
+            "(values in microseconds, k8s-style notation is not supported "
+            "by the engine).",
             FutureWarning,
             stacklevel=1,
         )
     if memory:
         warnings.warn(
-            "--memory is deprecated; pass the equivalent docker-py argument instead, "
-            "e.g.: -- --mem-limit <value>",
+            "--memory is deprecated; pass docker/podman args after '--' instead, "
+            "e.g. `-- --memory 512m` (engine accepts suffixes 'b/k/m/g', not "
+            "k8s-style 'Mi'/'Gi').",
             FutureWarning,
             stacklevel=1,
         )

--- a/client/gefyra/cli/utils.py
+++ b/client/gefyra/cli/utils.py
@@ -283,6 +283,65 @@ def check_connection_name(ctx, param, selected: Optional[str] = None) -> str:
         return connection_name
 
 
+def _coerce_value(value: str) -> Any:
+    """Try to coerce a string value to int, float, or bool."""
+    if value.lower() == "true":
+        return True
+    if value.lower() == "false":
+        return False
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return value
+
+
+def parse_extra_container_args(extra_args: List[str]) -> Dict[str, Any]:
+    """
+    Parse Click's extra args (unknown options) into a dict of docker-py kwargs.
+
+    Converts CLI-style args like ['--cpu-shares', '512', '--oom-kill-disable']
+    into docker-py kwargs like {'cpu_shares': 512, 'oom_kill_disable': True}.
+
+    Args that use '=' syntax are also supported: ['--cpu-shares=512'].
+    Boolean flags (no value) are set to True.
+    """
+    result: Dict[str, Any] = {}
+    i = 0
+    while i < len(extra_args):
+        arg = extra_args[i]
+        if not arg.startswith("--"):
+            raise click.UsageError(
+                f"Unknown extra argument '{arg}'. Extra container engine arguments"
+                " must start with '--'."
+            )
+
+        # Handle --key=value syntax
+        if "=" in arg:
+            key, value = arg.split("=", 1)
+            key = key.lstrip("-").replace("-", "_")
+            result[key] = _coerce_value(value)
+            i += 1
+            continue
+
+        key = arg.lstrip("-").replace("-", "_")
+
+        # Check if next arg is a value (not another flag)
+        if i + 1 < len(extra_args) and not extra_args[i + 1].startswith("--"):
+            result[key] = _coerce_value(extra_args[i + 1])
+            i += 2
+        else:
+            # Boolean flag
+            result[key] = True
+            i += 1
+
+    return result
+
+
 def parse_match_header(
     ctx, param, match_header_raw: Tuple[str]
 ) -> List[ExactMatchHeader | PrefixMatchHeader | RegexMatchHeader]:

--- a/client/gefyra/local/bridge.py
+++ b/client/gefyra/local/bridge.py
@@ -234,12 +234,16 @@ def deploy_app_container(
     # Extra args override built-in defaults if there is a key conflict.
     if extra_container_args:
         _gefyra_managed_keys = {"network", "dns", "dns_search", "pid_mode", "detach"}
-        for key in extra_container_args:
-            if key in _gefyra_managed_keys:
-                logger.warning(
-                    f"Extra arg '--{key.replace('_', '-')}' overrides a Gefyra-managed"
-                    " setting. This may break container networking."
-                )
+        _conflicts = [
+            key for key in extra_container_args if key in _gefyra_managed_keys
+        ]
+        if _conflicts:
+            pretty = ", ".join(f"--{k.replace('_', '-')}" for k in _conflicts)
+            raise ValueError(
+                f"Extra arg(s) {pretty} override Gefyra-managed settings and"
+                " may break container networking. Remove them from the extra"
+                " arguments."
+            )
         not_none_kwargs.update(extra_container_args)
 
     container = handle_docker_run_container(config, image, **not_none_kwargs)

--- a/client/gefyra/local/bridge.py
+++ b/client/gefyra/local/bridge.py
@@ -190,6 +190,7 @@ def deploy_app_container(
     user: Optional[str] = None,
     security_opts: Optional[List[str]] = None,
     privileged: Optional[bool] = None,
+    extra_container_args: Optional[Dict] = None,
 ) -> Container:
     import docker
 
@@ -228,6 +229,18 @@ def deploy_app_container(
         "privileged": privileged,
     }
     not_none_kwargs = {k: v for k, v in all_kwargs.items() if v is not None}
+
+    # Merge extra container engine args (e.g. --cpu-shares, --mem-reservation).
+    # Extra args override built-in defaults if there is a key conflict.
+    if extra_container_args:
+        _gefyra_managed_keys = {"network", "dns", "dns_search", "pid_mode", "detach"}
+        for key in extra_container_args:
+            if key in _gefyra_managed_keys:
+                logger.warning(
+                    f"Extra arg '--{key.replace('_', '-')}' overrides a Gefyra-managed"
+                    " setting. This may break container networking."
+                )
+        not_none_kwargs.update(extra_container_args)
 
     container = handle_docker_run_container(config, image, **not_none_kwargs)
 

--- a/client/tests/unit/test_extra_container_args.py
+++ b/client/tests/unit/test_extra_container_args.py
@@ -1,6 +1,5 @@
 import pytest
 import click
-from unittest import TestCase
 from click.testing import CliRunner
 
 from gefyra.cli.utils import parse_extra_container_args

--- a/client/tests/unit/test_extra_container_args.py
+++ b/client/tests/unit/test_extra_container_args.py
@@ -1,0 +1,116 @@
+import pytest
+import click
+from unittest import TestCase
+from click.testing import CliRunner
+
+from gefyra.cli.utils import parse_extra_container_args
+
+
+class TestParseExtraContainerArgs:
+    """Tests for the parse_extra_container_args helper."""
+
+    def test_empty_list(self):
+        assert parse_extra_container_args([]) == {}
+
+    def test_single_key_value(self):
+        result = parse_extra_container_args(["--cpu-shares", "512"])
+        assert result == {"cpu_shares": 512}
+
+    def test_multiple_key_values(self):
+        result = parse_extra_container_args(
+            ["--cpu-shares", "512", "--mem-reservation", "256m"]
+        )
+        assert result == {"cpu_shares": 512, "mem_reservation": "256m"}
+
+    def test_boolean_flag(self):
+        result = parse_extra_container_args(["--oom-kill-disable"])
+        assert result == {"oom_kill_disable": True}
+
+    def test_boolean_flag_with_other_args(self):
+        result = parse_extra_container_args(
+            ["--oom-kill-disable", "--cpu-shares", "512"]
+        )
+        assert result == {"oom_kill_disable": True, "cpu_shares": 512}
+
+    def test_equals_syntax(self):
+        result = parse_extra_container_args(["--cpu-shares=512"])
+        assert result == {"cpu_shares": 512}
+
+    def test_equals_syntax_with_string_value(self):
+        result = parse_extra_container_args(["--restart=always"])
+        assert result == {"restart": "always"}
+
+    def test_float_coercion(self):
+        result = parse_extra_container_args(["--cpu-count", "1.5"])
+        assert result == {"cpu_count": 1.5}
+
+    def test_bool_coercion_true(self):
+        result = parse_extra_container_args(["--privileged", "true"])
+        assert result == {"privileged": True}
+
+    def test_bool_coercion_false(self):
+        result = parse_extra_container_args(["--privileged", "false"])
+        assert result == {"privileged": False}
+
+    def test_string_value_preserved(self):
+        result = parse_extra_container_args(["--restart", "unless-stopped"])
+        assert result == {"restart": "unless-stopped"}
+
+    def test_invalid_arg_no_dashes(self):
+        with pytest.raises(click.UsageError, match="must start with '--'"):
+            parse_extra_container_args(["cpu-shares", "512"])
+
+    def test_mixed_equals_and_positional(self):
+        result = parse_extra_container_args(
+            ["--cpu-shares=512", "--mem-limit", "1g", "--oom-kill-disable"]
+        )
+        assert result == {
+            "cpu_shares": 512,
+            "mem_limit": "1g",
+            "oom_kill_disable": True,
+        }
+
+    def test_hyphen_to_underscore_conversion(self):
+        result = parse_extra_container_args(["--memory-swap", "2g"])
+        assert result == {"memory_swap": "2g"}
+
+    def test_single_word_flag(self):
+        result = parse_extra_container_args(["--init"])
+        assert result == {"init": True}
+
+    def test_integer_zero(self):
+        result = parse_extra_container_args(["--cpu-shares", "0"])
+        assert result == {"cpu_shares": 0}
+
+
+class TestRunCommandExtraArgs:
+    """Test that the run CLI command properly handles extra args."""
+
+    def test_help_shows_extra_args_info(self):
+        from gefyra.cli.run import run
+
+        runner = CliRunner()
+        result = runner.invoke(run, ["--help"])
+        assert "container engine arguments" in result.output
+
+    def test_unknown_option_does_not_fail_parsing(self):
+        """Verify that unknown options don't cause a Click error at parse time."""
+        from gefyra.cli.run import run
+
+        runner = CliRunner()
+        # This will fail at runtime (no connection), but should NOT fail at
+        # Click parse time with "no such option: --cpu-shares"
+        result = runner.invoke(
+            run,
+            [
+                "-i",
+                "alpine",
+                "-N",
+                "test",
+                "--",
+                "--cpu-shares",
+                "512",
+            ],
+        )
+        # Should fail with connection error, NOT "no such option"
+        assert "no such option" not in (result.output or "").lower()


### PR DESCRIPTION
Use Click's unknown-options forwarding so that any docker/podman parameter (e.g. --cpu-shares, --mem-reservation, --cpu-period) can be passed through to the container engine via `gefyra run ... -- --arg val`.

Deprecate the existing --cpu and --memory flags in favour of the generic passthrough. A warning is emitted when Gefyra-managed keys (network, dns, pid_mode) are overridden via extra args