### PR TITLE
refactor: remove same len check

### DIFF
--- a/operator/gefyra/bridge_mount/carrier2mount/__init__.py
+++ b/operator/gefyra/bridge_mount/carrier2mount/__init__.py
@@ -696,7 +696,6 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
         )
         gefyra_pod_len = len((await self._gefyra_pods).items)
         original_pod_len = len((await self._original_pods).items)
-        same_amount = gefyra_pod_len == original_pod_len
         if not ready:
             self.logger.info(
                 "GefyraBridgeMount is not ready yet: "
@@ -708,7 +707,7 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
                 f"Gefyra pod count: {gefyra_pod_len}"
             )
         # consider down scaling & up scaling
-        return ready and same_amount
+        return ready
 
     async def validate(self, bridge_request, hints):
         required_fields = ["target", "targetNamespace", "targetContainer"]


### PR DESCRIPTION
This PR removes the check for the same amount of gefyra pods and original pods in the readiness check of the GefyraBridgeMount. This is because the number of pods can differ during scaling operations, and it should not affect the readiness of the bridge mount.