### PR TITLE
Go 1030

### DIFF
--- a/operator/gefyra/bridge_mount/carrier2mount/__init__.py
+++ b/operator/gefyra/bridge_mount/carrier2mount/__init__.py
@@ -27,12 +27,20 @@ from gefyra.bridge_mount.carrier2mount.hpa import (
     clone_hpa_for_shadow,
     delete_duplicated_hpa,
     find_hpa_for_target,
+    read_duplicated_hpa,
+)
+from gefyra.bridge_mount.carrier2mount.source_hash import (
+    SOURCE_HPA_HASH_ANNOTATION,
+    SOURCE_WORKLOAD_HASH_ANNOTATION,
+    hash_hpa_source,
+    hash_workload_source,
 )
 from gefyra.configuration import OperatorConfiguration
 
 from gefyra.bridge.carrier2.config import Carrier2Config, Carrier2Proxy, CarrierProbe
 from gefyra.bridge_mount.utils import (
     _get_tls_from_provider_parameters,
+    generate_duplicate_hpa_name,
     generate_duplicate_workload_name,
     generate_duplicate_svc_name,
     generate_k8s_conform_name,
@@ -195,7 +203,9 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
         return name, type_
 
     def _clone_workload_structure(
-        self, workload: V1Deployment | V1StatefulSet | V1Pod
+        self,
+        workload: V1Deployment | V1StatefulSet | V1Pod,
+        duplication_id: str | None = None,
     ) -> V1Deployment | V1StatefulSet | V1Pod:
         new_workload = deepcopy(workload)
 
@@ -209,7 +219,10 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
             workload.metadata.name
         )
 
-        duplication_id = str(uuid.uuid4())
+        # Reuse an existing duplication-id when re-reconciling an existing
+        # shadow, so the service selector (pinned to that id) keeps matching
+        # pods across re-applies.
+        duplication_id = duplication_id or str(uuid.uuid4())
         self._duplication_id = duplication_id
         if isinstance(workload, (V1Deployment, V1StatefulSet)):
             pod_labels = self._get_duplication_labels(
@@ -232,6 +245,18 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
             new_workload.metadata.annotations or {}
         )
         return new_workload
+
+    @staticmethod
+    def _extract_duplication_id(
+        shadow: V1Deployment | V1StatefulSet | V1Pod,
+    ) -> str | None:
+        if isinstance(shadow, (V1Deployment, V1StatefulSet)):
+            template = shadow.spec.template if shadow.spec else None
+            meta = template.metadata if template else None
+            labels = (meta.labels if meta else None) or {}
+        else:
+            labels = (shadow.metadata.labels if shadow.metadata else None) or {}
+        return labels.get(DUPLICATION_ID_LABEL)
 
     def _get_svc_for_workload(
         self, workload: V1Deployment | V1StatefulSet | V1Pod
@@ -262,37 +287,99 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
             ),
         )
 
+    async def _read_existing_shadow(
+        self,
+    ) -> V1Deployment | V1StatefulSet | V1Pod | None:
+        """Return the currently deployed shadow workload, or None if it does
+        not exist yet. Any other API error bubbles up."""
+        _, type_ = self._split_target_type_name(self.target)
+        try:
+            return await asyncio.to_thread(
+                self._read_namespaced_(type_),
+                self._gefyra_workload_name,
+                self.namespace,
+            )
+        except ApiException as e:
+            if e.status == 404:
+                return None
+            raise
+
     async def _duplicate_workload(self) -> None:
         workload = await self._get_workload(self.target, self.namespace)
+        source_hash = hash_workload_source(workload)
 
-        # Create a copy of the workload
+        existing_shadow = await self._read_existing_shadow()
+        if existing_shadow is not None:
+            # Remember the existing duplication-id up front, so downstream
+            # cleanup paths (HPA, service) can always resolve it even if we
+            # take the skip branch below.
+            existing_duplication_id = self._extract_duplication_id(existing_shadow)
+            if existing_duplication_id:
+                self._duplication_id = existing_duplication_id
 
-        new_workload = self._clone_workload_structure(workload)
+            existing_annotations = existing_shadow.metadata.annotations or {}
+            if existing_annotations.get(SOURCE_WORKLOAD_HASH_ANNOTATION) == source_hash:
+                self.logger.info(
+                    f"Source workload '{workload.metadata.name}' unchanged "
+                    f"(hash {source_hash[:12]}); keeping shadow "
+                    f"'{self._gefyra_workload_name}' in place."
+                )
+                # HPA may still need syncing (its own hash check is idempotent).
+                await self._duplicate_hpa_if_present()
+                return
+
+        # Build the shadow spec. Reuse the existing duplication-id (if any)
+        # so the service selector continues to match running pods.
+        new_workload = self._clone_workload_structure(
+            workload, duplication_id=self._duplication_id
+        )
+        new_workload.metadata.annotations = {
+            **(new_workload.metadata.annotations or {}),
+            SOURCE_WORKLOAD_HASH_ANNOTATION: source_hash,
+        }
         new_svc = self._get_svc_for_workload(new_workload)
 
-        # Create the new workload
-        try:
+        if existing_shadow is None:
+            try:
+                await asyncio.to_thread(
+                    self._create_namespaced_(workload.__class__),
+                    self.namespace,
+                    new_workload,
+                )
+                await self.post_event(
+                    "Cluster upstream",
+                    f"Created cluster upstream '{new_workload.metadata.name}' "
+                    f"for target workload '{workload.metadata.name}' in namespace '{self.namespace}'.",
+                    "Normal",
+                )
+            except ApiException as e:
+                if e.status == 409:
+                    # Lost a race: another reconciliation created the shadow.
+                    # Fall through to the patch path on the next tick.
+                    self.logger.info(
+                        f"Shadow workload '{new_workload.metadata.name}' was "
+                        f"created concurrently; will reconcile next tick."
+                    )
+                    return
+                raise BridgeInstallException(f"Exception when creating workload: {e}")
+        else:
+            # Patch path: the shadow's replica count is owned by the
+            # duplicated HPA (see GO-1030); do not reset it here.
+            if hasattr(new_workload.spec, "replicas"):
+                new_workload.spec.replicas = None
             await asyncio.to_thread(
-                self._create_namespaced_(workload.__class__),
-                self.namespace,
-                new_workload,
+                self._patch_namespaced_(workload.__class__),
+                name=new_workload.metadata.name,
+                namespace=self.namespace,
+                body=new_workload,
             )
             await self.post_event(
                 "Cluster upstream",
-                f"Created cluster upstream '{new_workload.metadata.name}' "
-                f"for target workload '{workload.metadata.name}' in namespace '{self.namespace}'.",
+                f"Re-applied cluster upstream '{new_workload.metadata.name}' "
+                f"after source workload change (hash {source_hash[:12]}).",
                 "Normal",
             )
-        except ApiException as e:
-            if e.status == 409:
-                await asyncio.to_thread(
-                    self._patch_namespaced_(workload.__class__),
-                    name=new_workload.metadata.name,
-                    namespace=self.namespace,
-                    body=new_workload,
-                )
-            else:
-                raise BridgeInstallException(f"Exception when creating workload: {e}")
+
         try:
             await asyncio.to_thread(
                 core_v1_api.create_namespaced_service,
@@ -326,11 +413,20 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
             return "StatefulSet"
         return None
 
+    async def _read_existing_shadow_hpa(self, name: str):
+        return await asyncio.to_thread(
+            read_duplicated_hpa, self.namespace, name
+        )
+
     async def _duplicate_hpa_if_present(self) -> None:
         """Discover an HPA on the original workload and duplicate it onto the
         shadow workload. Optional feature: failures are logged but never raise,
         so HPA-less workloads and clusters without RBAC for autoscaling/v2
-        keep working as before."""
+        keep working as before.
+
+        Idempotent: if the duplicated HPA already exists and its source-hash
+        annotation matches the original, the call is a no-op — no write to the
+        apiserver, no perturbation of shadow scaling decisions."""
         target_kind = self._hpa_target_kind()
         if target_kind is None:
             # Pods aren't HPA targets.
@@ -352,6 +448,23 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
                 return
 
             self._original_hpa_name = original_hpa.metadata.name
+            source_hash = hash_hpa_source(original_hpa)
+
+            duplicated_name = generate_duplicate_hpa_name(
+                original_hpa.metadata.name
+            )
+            existing = await self._read_existing_shadow_hpa(duplicated_name)
+            if existing is not None:
+                existing_hash = (existing.metadata.annotations or {}).get(
+                    SOURCE_HPA_HASH_ANNOTATION
+                )
+                if existing_hash == source_hash:
+                    self.logger.info(
+                        f"HPA '{original_hpa.metadata.name}' unchanged "
+                        f"(hash {source_hash[:12]}); keeping duplicated "
+                        f"HPA '{duplicated_name}' in place."
+                    )
+                    return
 
             duplication_labels = self._get_duplication_labels(
                 original_hpa.metadata.labels or {}
@@ -364,10 +477,15 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
                 shadow_workload_name=self._gefyra_workload_name,
                 duplication_labels=duplication_labels,
             )
+            cloned.metadata.annotations = {
+                **(cloned.metadata.annotations or {}),
+                SOURCE_HPA_HASH_ANNOTATION: source_hash,
+            }
             await asyncio.to_thread(apply_cloned_hpa, self.namespace, cloned)
+            verb = "Updated" if existing is not None else "Duplicated"
             await self.post_event(
                 "Cluster upstream HPA",
-                f"Duplicated HPA '{original_hpa.metadata.name}' as "
+                f"{verb} HPA '{original_hpa.metadata.name}' as "
                 f"'{cloned.metadata.name}' targeting shadow workload "
                 f"'{self._gefyra_workload_name}' in namespace "
                 f"'{self.namespace}'.",
@@ -389,22 +507,12 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
         if self._duplication_id:
             return self._duplication_id
         try:
-            shadow = await asyncio.to_thread(
-                self._read_namespaced_(self._split_target_type_name(self.target)[1]),
-                self._gefyra_workload_name,
-                self.namespace,
-            )
+            shadow = await self._read_existing_shadow()
         except ApiException:
             return None
-        if isinstance(shadow, (V1Deployment, V1StatefulSet)):
-            labels = (
-                shadow.spec.template.metadata.labels
-                if shadow.spec.template and shadow.spec.template.metadata
-                else None
-            ) or {}
-        else:
-            labels = (shadow.metadata.labels if shadow.metadata else None) or {}
-        duplication_id = labels.get(DUPLICATION_ID_LABEL)
+        if shadow is None:
+            return None
+        duplication_id = self._extract_duplication_id(shadow)
         if duplication_id:
             self._duplication_id = duplication_id
         return duplication_id

--- a/operator/gefyra/bridge_mount/carrier2mount/__init__.py
+++ b/operator/gefyra/bridge_mount/carrier2mount/__init__.py
@@ -21,6 +21,13 @@ from kubernetes.client import (
 import asyncio  # Added asyncio import
 
 from gefyra.bridge_mount.abstract import AbstractGefyraBridgeMountProvider
+from gefyra.bridge_mount.carrier2mount.hpa import (
+    DUPLICATION_ID_LABEL,
+    apply_cloned_hpa,
+    clone_hpa_for_shadow,
+    delete_duplicated_hpa,
+    find_hpa_for_target,
+)
 from gefyra.configuration import OperatorConfiguration
 
 from gefyra.bridge.carrier2.config import Carrier2Config, Carrier2Proxy, CarrierProbe
@@ -71,6 +78,8 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
         self.post_event = post_event_function
         self.logger = logger
         self.params = kwargs.get("parameter", {})
+        self._duplication_id: str | None = None
+        self._original_hpa_name: str | None = None
 
     def _get_duplication_labels(self, labels: dict[str, str]) -> dict[str, str]:
         duplication_labels = {}
@@ -200,12 +209,14 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
             workload.metadata.name
         )
 
+        duplication_id = str(uuid.uuid4())
+        self._duplication_id = duplication_id
         if isinstance(workload, (V1Deployment, V1StatefulSet)):
             pod_labels = self._get_duplication_labels(
                 new_workload.spec.template.metadata.labels or {}
             )
             # we use this for svc selector
-            pod_labels["bridge.gefyra.dev/duplication-id"] = str(uuid.uuid4())
+            pod_labels[DUPLICATION_ID_LABEL] = duplication_id
             new_workload.spec.template.metadata.labels = pod_labels
 
             match_labels = self._get_duplication_labels(
@@ -214,7 +225,7 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
             new_workload.spec.selector.match_labels = match_labels
         else:
             # we use this for svc selector
-            labels["bridge.gefyra.dev/duplication-id"] = str(uuid.uuid4())
+            labels[DUPLICATION_ID_LABEL] = duplication_id
             new_workload.metadata.labels = labels
 
         new_workload.metadata.annotations = self._clean_annotations(
@@ -228,15 +239,13 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
         name, _ = self._split_target_type_name(self.target)
         if isinstance(workload, (V1Deployment, V1StatefulSet)):
             selector_ = {
-                "bridge.gefyra.dev/duplication-id": workload.spec.template.metadata.labels[
-                    "bridge.gefyra.dev/duplication-id"
+                DUPLICATION_ID_LABEL: workload.spec.template.metadata.labels[
+                    DUPLICATION_ID_LABEL
                 ]
             }
         else:
             selector_ = {
-                "bridge.gefyra.dev/duplication-id": workload.metadata.labels[
-                    "bridge.gefyra.dev/duplication-id"
-                ]
+                DUPLICATION_ID_LABEL: workload.metadata.labels[DUPLICATION_ID_LABEL]
             }
         return V1Service(
             metadata=V1ObjectMeta(
@@ -306,6 +315,118 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
                 )
             else:
                 raise BridgeInstallException(f"Exception when creating service: {e}")
+
+        await self._duplicate_hpa_if_present()
+
+    def _hpa_target_kind(self) -> str | None:
+        _, type_ = self._split_target_type_name(self.target)
+        if type_ is V1Deployment:
+            return "Deployment"
+        if type_ is V1StatefulSet:
+            return "StatefulSet"
+        return None
+
+    async def _duplicate_hpa_if_present(self) -> None:
+        """Discover an HPA on the original workload and duplicate it onto the
+        shadow workload. Optional feature: failures are logged but never raise,
+        so HPA-less workloads and clusters without RBAC for autoscaling/v2
+        keep working as before."""
+        target_kind = self._hpa_target_kind()
+        if target_kind is None:
+            # Pods aren't HPA targets.
+            return
+        target_name, _ = self._split_target_type_name(self.target)
+        try:
+            original_hpa = await asyncio.to_thread(
+                find_hpa_for_target,
+                self.namespace,
+                target_kind,
+                target_name,
+                self.logger,
+            )
+            if original_hpa is None:
+                self.logger.info(
+                    f"No HPA found for {target_kind}/{target_name} in "
+                    f"namespace '{self.namespace}'. Skipping HPA duplication."
+                )
+                return
+
+            self._original_hpa_name = original_hpa.metadata.name
+
+            duplication_labels = self._get_duplication_labels(
+                original_hpa.metadata.labels or {}
+            )
+            if self._duplication_id:
+                duplication_labels[DUPLICATION_ID_LABEL] = self._duplication_id
+
+            cloned = clone_hpa_for_shadow(
+                original_hpa=original_hpa,
+                shadow_workload_name=self._gefyra_workload_name,
+                duplication_labels=duplication_labels,
+            )
+            await asyncio.to_thread(apply_cloned_hpa, self.namespace, cloned)
+            await self.post_event(
+                "Cluster upstream HPA",
+                f"Duplicated HPA '{original_hpa.metadata.name}' as "
+                f"'{cloned.metadata.name}' targeting shadow workload "
+                f"'{self._gefyra_workload_name}' in namespace "
+                f"'{self.namespace}'.",
+                "Normal",
+            )
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to duplicate HPA for {target_kind}/{target_name} "
+                f"in namespace '{self.namespace}': {e}. The shadow workload "
+                f"will not auto-scale."
+            )
+            await self.post_event(
+                "Cluster upstream HPA",
+                f"Failed to duplicate HPA for {target_kind}/{target_name}: {e}",
+                "Warning",
+            )
+
+    async def _resolve_duplication_id(self) -> str | None:
+        if self._duplication_id:
+            return self._duplication_id
+        try:
+            shadow = await asyncio.to_thread(
+                self._read_namespaced_(self._split_target_type_name(self.target)[1]),
+                self._gefyra_workload_name,
+                self.namespace,
+            )
+        except ApiException:
+            return None
+        if isinstance(shadow, (V1Deployment, V1StatefulSet)):
+            labels = (
+                shadow.spec.template.metadata.labels
+                if shadow.spec.template and shadow.spec.template.metadata
+                else None
+            ) or {}
+        else:
+            labels = (shadow.metadata.labels if shadow.metadata else None) or {}
+        duplication_id = labels.get(DUPLICATION_ID_LABEL)
+        if duplication_id:
+            self._duplication_id = duplication_id
+        return duplication_id
+
+    async def _uninstall_duplicated_hpa(self) -> None:
+        if self._hpa_target_kind() is None:
+            return
+        try:
+            duplication_id = await self._resolve_duplication_id()
+            await asyncio.to_thread(
+                delete_duplicated_hpa,
+                self.namespace,
+                self._original_hpa_name,
+                duplication_id,
+                self.logger,
+            )
+        except Exception as e:
+            # A dangling HPA can be cleaned up manually; never block restore.
+            self.logger.error(
+                f"Failed to clean up duplicated HPA for {self.name} "
+                f"in namespace '{self.namespace}': {e}"
+            )
 
     async def _get_workload(
         self, target: str, namespace: str
@@ -649,36 +770,7 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
             )
         return new_workload
 
-    async def _scale_shadow_to_match(self, target_replicas: int) -> None:
-        """Scale the shadow deployment to match the original's replica count."""
-        _, type_ = self._split_target_type_name(self.target)
-        if type_ not in (V1Deployment, V1StatefulSet):
-            return
-        patch_fn = self._patch_namespaced_(type_)
-        body = {"spec": {"replicas": target_replicas}}
-        await asyncio.to_thread(
-            patch_fn,
-            name=self._gefyra_workload_name,
-            namespace=self.namespace,
-            body=body,
-        )
-        self.logger.info(
-            f"Scaled shadow workload '{self._gefyra_workload_name}' "
-            f"to {target_replicas} replicas to match original."
-        )
-
     async def prepared(self):
-        gefyra_pods = await self._gefyra_pods
-        original_pods = await self._original_pods
-        if len(gefyra_pods.items) != len(original_pods.items):
-            self.logger.info(
-                f"Replica count mismatch: original={len(original_pods.items)}, "
-                f"gefyra={len(gefyra_pods.items)}. "
-                f"Scaling shadow to match."
-            )
-            await self._scale_shadow_to_match(len(original_pods.items))
-            return False
-
         pods_ready = await self._duplicated_pods_ready
         if not pods_ready:
             self.logger.info(
@@ -693,21 +785,15 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
             and await self._original_pods_ready
             and await self._upstream_set
         )
-        gefyra_pod_len = len((await self._gefyra_pods).items)
-        original_pod_len = len((await self._original_pods).items)
-        same_amount = gefyra_pod_len == original_pod_len
         if not ready:
             self.logger.info(
                 "GefyraBridgeMount is not ready yet: "
                 f"duplicated pods ready: {await self._duplicated_pods_ready}, "
                 f"carrier installed: {await self._carrier_installed}, "
                 f"original pods ready: {await self._original_pods_ready}, "
-                f"upstream set: {await self._upstream_set},"
-                f"original pod count: {original_pod_len}, "
-                f"Gefyra pod count: {gefyra_pod_len}"
+                f"upstream set: {await self._upstream_set}"
             )
-        # consider down scaling & up scaling
-        return ready and same_amount
+        return ready
 
     async def validate(self, bridge_request, hints):
         required_fields = ["target", "targetNamespace", "targetContainer"]
@@ -880,6 +966,7 @@ class Carrier2BridgeMount(AbstractGefyraBridgeMountProvider):
     async def uninstall(self):
         await self.uninstall_duplicated_workload()
         await self.uninstall_service()
+        await self._uninstall_duplicated_hpa()
         try:
             await self.restore_original_workload()
         except Exception as e:

--- a/operator/gefyra/bridge_mount/carrier2mount/hpa.py
+++ b/operator/gefyra/bridge_mount/carrier2mount/hpa.py
@@ -1,0 +1,174 @@
+from copy import deepcopy
+from typing import Optional
+
+import kubernetes as k8s
+from kubernetes.client import (
+    ApiException,
+    V2HorizontalPodAutoscaler,
+)
+
+from gefyra.bridge_mount.utils import generate_duplicate_hpa_name
+
+
+DUPLICATION_ID_LABEL = "bridge.gefyra.dev/duplication-id"
+
+ANNOTATION_FILTER = (
+    "kubectl.kubernetes.io/last-applied-configuration",
+    "deployment.kubernetes.io/revision",
+)
+
+
+def _autoscaling_api() -> "k8s.client.AutoscalingV2Api":
+    return k8s.client.AutoscalingV2Api()
+
+
+def _scale_target_kind_matches(ref_kind: str, target_kind: str) -> bool:
+    if not ref_kind:
+        return False
+    return ref_kind.lower() == target_kind.lower()
+
+
+def find_hpa_for_target(
+    namespace: str,
+    target_kind: str,
+    target_name: str,
+    logger,
+) -> Optional[V2HorizontalPodAutoscaler]:
+    """Return the first HPA in `namespace` that targets `target_kind/target_name`.
+
+    Multiple matches are a misconfiguration on the cluster — log a warning and
+    return the first one. Any API error (e.g. RBAC) degrades to None so that
+    HPA support is best-effort and does not block mount creation.
+    """
+    try:
+        hpas = _autoscaling_api().list_namespaced_horizontal_pod_autoscaler(
+            namespace=namespace
+        )
+    except ApiException as e:
+        logger.warning(
+            f"Cannot list HPAs in namespace '{namespace}' "
+            f"(status {e.status}): {e.reason}. Skipping HPA duplication."
+        )
+        return None
+
+    matches = []
+    for hpa in hpas.items:
+        ref = hpa.spec.scale_target_ref if hpa.spec else None
+        if (
+            ref
+            and _scale_target_kind_matches(ref.kind, target_kind)
+            and ref.name == target_name
+        ):
+            matches.append(hpa)
+
+    if not matches:
+        return None
+    if len(matches) > 1:
+        names = ", ".join(m.metadata.name for m in matches)
+        logger.warning(
+            f"Multiple HPAs target {target_kind}/{target_name} in namespace "
+            f"'{namespace}' ({names}). Duplicating only the first one."
+        )
+    return matches[0]
+
+
+def clone_hpa_for_shadow(
+    original_hpa: V2HorizontalPodAutoscaler,
+    shadow_workload_name: str,
+    duplication_labels: dict,
+) -> V2HorizontalPodAutoscaler:
+    """Clone an HPA so that the duplicate targets the shadow workload."""
+    new_hpa = deepcopy(original_hpa)
+
+    new_hpa.metadata.name = generate_duplicate_hpa_name(original_hpa.metadata.name)
+    new_hpa.metadata.resource_version = None
+    new_hpa.metadata.uid = None
+    new_hpa.metadata.creation_timestamp = None
+    new_hpa.metadata.managed_fields = None
+    new_hpa.metadata.generation = None
+    new_hpa.metadata.owner_references = None
+    new_hpa.metadata.self_link = None
+
+    annotations = new_hpa.metadata.annotations or {}
+    new_hpa.metadata.annotations = {
+        k: v
+        for k, v in annotations.items()
+        if k not in ANNOTATION_FILTER
+        and not k.startswith("autoscaling.alpha.kubernetes.io/")
+    } or None
+
+    new_hpa.metadata.labels = dict(duplication_labels)
+
+    new_hpa.spec.scale_target_ref.name = shadow_workload_name
+
+    new_hpa.status = None
+    return new_hpa
+
+
+def apply_cloned_hpa(namespace: str, cloned_hpa: V2HorizontalPodAutoscaler) -> None:
+    api = _autoscaling_api()
+    try:
+        api.create_namespaced_horizontal_pod_autoscaler(
+            namespace=namespace, body=cloned_hpa
+        )
+    except ApiException as e:
+        if e.status == 409:
+            api.patch_namespaced_horizontal_pod_autoscaler(
+                name=cloned_hpa.metadata.name,
+                namespace=namespace,
+                body=cloned_hpa,
+            )
+        else:
+            raise
+
+
+def delete_duplicated_hpa(
+    namespace: str,
+    original_hpa_name: Optional[str],
+    duplication_id: Optional[str],
+    logger,
+) -> None:
+    """Delete the duplicated HPA. Tries direct delete first (if the name is
+    derivable), then falls back to label-selector cleanup so dangling clones
+    are removed even when the original HPA has disappeared in the meantime."""
+    api = _autoscaling_api()
+
+    if original_hpa_name:
+        name = generate_duplicate_hpa_name(original_hpa_name)
+        try:
+            api.delete_namespaced_horizontal_pod_autoscaler(
+                name=name, namespace=namespace
+            )
+        except ApiException as e:
+            if e.status != 404:
+                logger.warning(
+                    f"Failed to delete duplicated HPA '{name}' in "
+                    f"namespace '{namespace}': {e.reason} (status {e.status})"
+                )
+
+    if not duplication_id:
+        return
+
+    try:
+        leftovers = api.list_namespaced_horizontal_pod_autoscaler(
+            namespace=namespace,
+            label_selector=f"{DUPLICATION_ID_LABEL}={duplication_id}",
+        )
+    except ApiException as e:
+        logger.warning(
+            f"Failed to list duplicated HPAs by label in namespace "
+            f"'{namespace}': {e.reason} (status {e.status})"
+        )
+        return
+
+    for hpa in leftovers.items:
+        try:
+            api.delete_namespaced_horizontal_pod_autoscaler(
+                name=hpa.metadata.name, namespace=namespace
+            )
+        except ApiException as e:
+            if e.status != 404:
+                logger.warning(
+                    f"Failed to delete duplicated HPA '{hpa.metadata.name}' "
+                    f"in namespace '{namespace}': {e.reason} (status {e.status})"
+                )

--- a/operator/gefyra/bridge_mount/carrier2mount/hpa.py
+++ b/operator/gefyra/bridge_mount/carrier2mount/hpa.py
@@ -105,6 +105,21 @@ def clone_hpa_for_shadow(
     return new_hpa
 
 
+def read_duplicated_hpa(
+    namespace: str, name: str
+) -> Optional[V2HorizontalPodAutoscaler]:
+    """Return the duplicated HPA if present, None on 404. Other errors bubble
+    up so the caller can decide how to handle them."""
+    try:
+        return _autoscaling_api().read_namespaced_horizontal_pod_autoscaler(
+            name=name, namespace=namespace
+        )
+    except ApiException as e:
+        if e.status == 404:
+            return None
+        raise
+
+
 def apply_cloned_hpa(namespace: str, cloned_hpa: V2HorizontalPodAutoscaler) -> None:
     api = _autoscaling_api()
     try:

--- a/operator/gefyra/bridge_mount/carrier2mount/source_hash.py
+++ b/operator/gefyra/bridge_mount/carrier2mount/source_hash.py
@@ -1,0 +1,83 @@
+"""Idempotency helpers: hash the "meaningful" parts of the source workload /
+HPA so re-reconciliations don't needlessly patch the shadow deployment.
+
+A patch triggers a rolling restart of the shadow pods — expensive for
+workloads with long startup (e.g. JVM apps) and pointless if nothing on the
+source that actually matters for the shadow has changed. The hashes are
+persisted as annotations on the shadow object, so they survive operator
+restarts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from kubernetes.client import ApiClient
+
+SOURCE_WORKLOAD_HASH_ANNOTATION = "gefyra.dev/source-spec-hash"
+SOURCE_HPA_HASH_ANNOTATION = "gefyra.dev/source-hpa-spec-hash"
+
+_api_client = ApiClient()
+
+
+def _to_plain(obj: Any) -> Any:
+    return _api_client.sanitize_for_serialization(obj)
+
+
+def _strip_volatile(payload: Any) -> Any:
+    """Drop keys that change on every apiserver read but don't describe what
+    the workload *is* (bookkeeping / server-set fields)."""
+    _VOLATILE_METADATA_KEYS = (
+        "resourceVersion",
+        "uid",
+        "generation",
+        "creationTimestamp",
+        "managedFields",
+        "selfLink",
+        "ownerReferences",
+    )
+    if isinstance(payload, dict):
+        meta = payload.get("metadata")
+        if isinstance(meta, dict):
+            for key in _VOLATILE_METADATA_KEYS:
+                meta.pop(key, None)
+        for value in payload.values():
+            _strip_volatile(value)
+    elif isinstance(payload, list):
+        for value in payload:
+            _strip_volatile(value)
+    return payload
+
+
+def _digest(payload: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode()
+    ).hexdigest()
+
+
+def hash_workload_source(workload) -> str:
+    """Hash the pod template (for Deployments/StatefulSets) or pod spec (for
+    bare Pods). Intentionally excludes ``spec.replicas``, ``status`` and any
+    volatile server-side metadata so HPA-driven replica changes on the source
+    don't trigger shadow churn."""
+    spec = getattr(workload, "spec", None)
+    template = getattr(spec, "template", None) if spec is not None else None
+    if template is not None:
+        payload = _to_plain(template)
+    else:
+        # Pod target: hash the pod's own spec only (skip status/metadata).
+        payload = {"spec": _to_plain(spec)} if spec is not None else {}
+    _strip_volatile(payload)
+    return _digest(payload)
+
+
+def hash_hpa_source(hpa) -> str:
+    """Hash the HPA spec minus ``scaleTargetRef.name`` (which intentionally
+    differs between original and duplicate)."""
+    spec = _to_plain(getattr(hpa, "spec", None)) or {}
+    target_ref = spec.get("scaleTargetRef")
+    if isinstance(target_ref, dict):
+        target_ref.pop("name", None)
+    return _digest(spec)

--- a/operator/gefyra/bridge_mount/utils.py
+++ b/operator/gefyra/bridge_mount/utils.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, TYPE_CHECKING
 import kubernetes as k8s
 from kubernetes.client import (
     V1Deployment,
@@ -10,7 +10,8 @@ from kubernetes.client import (
     V1Probe,
 )
 
-from gefyra.bridge.carrier2.config import CarrierTLS
+if TYPE_CHECKING:
+    from gefyra.bridge.carrier2.config import CarrierTLS
 
 core_v1_api = k8s.client.CoreV1Api()
 
@@ -46,6 +47,11 @@ def generate_duplicate_workload_name(workload_name: str):
     return generate_k8s_conform_name(workload_name, suffix)
 
 
+def generate_duplicate_hpa_name(hpa_name: str) -> str:
+    suffix = "-gefyra"
+    return generate_k8s_conform_name(hpa_name, suffix)
+
+
 def get_duplicate_svc_fqdn(
     workload_name: str, container_name: str, namespace: str
 ) -> str:
@@ -75,7 +81,9 @@ def get_ports_for_workload(
 
 def _get_tls_from_provider_parameters(
     params: dict, rport: int | None = None
-) -> CarrierTLS | None:
+) -> "CarrierTLS | None":
+    from gefyra.bridge.carrier2.config import CarrierTLS
+
     if rport and str(rport) in params and "tls" in params[str(rport)]:
         return CarrierTLS(
             certificate=params[str(rport)]["tls"]["certificate"],

--- a/operator/gefyra/handler/bridge_mounts.py
+++ b/operator/gefyra/handler/bridge_mounts.py
@@ -25,7 +25,7 @@ async def bridge_mount_created(body, logger, **kwargs):
         if bridge_mount.installing.is_active:
             if not await bridge_mount.bridge_mount_provider.prepared():
                 raise kopf.TemporaryError(
-                    "Shadow replica count syncing with original", delay=10
+                    "Shadow pods not ready yet", delay=10
                 )
             elif await bridge_mount.bridge_mount_provider.ready():
                 await bridge_mount.activate()
@@ -153,7 +153,7 @@ async def bridge_mount_reconcile(body, logger, **kwargs):
                 ):
                     if not await bridge_mount.bridge_mount_provider.prepared():
                         logger.info(
-                            "Shadow replica count syncing with original. "
+                            "Shadow pods not ready yet. "
                             "Will retry on next reconciliation."
                         )
                     else:

--- a/operator/tests/fixtures/nginx_hpa.yaml
+++ b/operator/tests/fixtures/nginx_hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nginx-deployment-hpa
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx-deployment
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50

--- a/operator/tests/integration/test_bridge_mount_hpa_scale.py
+++ b/operator/tests/integration/test_bridge_mount_hpa_scale.py
@@ -157,6 +157,56 @@ class TestBridgeMountHPADuplication:
             )
         assert bm.terminated.is_active
 
+    async def test_reconcile_is_noop_when_source_unchanged(
+        self, gefyra_crd: AClusterManager
+    ):
+        """Re-running the duplication flow without changes to the source must
+        not roll the shadow pods — this protects long-starting workloads
+        (JVM apps etc.) from repeated downtime on every reconciliation."""
+        name = "nginx-deployment"
+        namespace = "default"
+        shadow = name + "-gefyra"
+
+        gefyra_crd.apply(NGINX_FIXTURE)
+        gefyra_crd.wait(
+            "deployment/" + name,
+            "jsonpath='{.status.readyReplicas}'=1",
+            namespace=namespace,
+            timeout=120,
+        )
+
+        bm = _make_bridge_mount(name, namespace)
+        try:
+            await _drive_to_active(bm)
+            assert bm.active.is_active
+
+            shadow_before = gefyra_crd.kubectl(
+                ["-n", namespace, "get", "deploy", shadow, "-o", "json"]
+            )
+            rv_before = shadow_before["metadata"]["resourceVersion"]
+            uid_before = shadow_before["metadata"]["uid"]
+
+            # Trigger another duplication pass; this mimics what every
+            # reconcile tick does when the state machine re-enters PREPARING.
+            await bm.bridge_mount_provider._duplicate_workload()
+
+            shadow_after = gefyra_crd.kubectl(
+                ["-n", namespace, "get", "deploy", shadow, "-o", "json"]
+            )
+            assert shadow_after["metadata"]["uid"] == uid_before
+            assert shadow_after["metadata"]["resourceVersion"] == rv_before, (
+                "resourceVersion changed — the operator re-applied the shadow "
+                "deployment even though the source was unchanged."
+            )
+        finally:
+            await bm.terminate()
+            gefyra_crd.wait(
+                "deployment/" + shadow,
+                "delete",
+                namespace=namespace,
+                timeout=60,
+            )
+
     async def test_mount_without_hpa_succeeds(self, gefyra_crd: AClusterManager):
         """No HPA on the original → mount still reaches ACTIVE, no shadow HPA
         is created, no errors raised."""

--- a/operator/tests/integration/test_bridge_mount_hpa_scale.py
+++ b/operator/tests/integration/test_bridge_mount_hpa_scale.py
@@ -1,46 +1,169 @@
 """
-Integration test: BridgeMount must reach ACTIVE even when the original
-deployment is scaled (simulating HPA) during the PREPARING/INSTALLING phase.
+Integration tests covering HPA duplication for shadow deployments (GO-1030).
 
-Without the fix, the mount would loop forever in PREPARING because
-prepared() always sees a replica count mismatch.
+When a GefyraBridgeMount is created and the original workload has an HPA, the
+operator must clone the HPA, retarget it to the shadow workload and clean up
+the duplicate when the mount is removed. Workloads without an HPA must still
+mount cleanly.
 """
 
 import logging
+from pathlib import Path
 from time import sleep
 from unittest.mock import MagicMock
 
-from pathlib import Path
 from pytest_kubernetes.providers import AClusterManager
 from statemachine.exceptions import TransitionNotAllowed
 
+from gefyra.bridge_mount.utils import generate_duplicate_hpa_name
 from gefyra.configuration import OperatorConfiguration
 
 logger = logging.getLogger()
 logger.addHandler(logging.NullHandler())
 
 
-class TestBridgeMountHPAScale:
-    async def test_mount_reaches_active_despite_scaling(
-        self, gefyra_crd: AClusterManager
-    ):
-        """Simulate HPA: scale original deployment while mount is installing.
+NGINX_FIXTURE = str(
+    Path(Path(__file__).parent.parent, "fixtures/nginx.yaml").absolute()
+)
+HPA_FIXTURE = str(
+    Path(Path(__file__).parent.parent, "fixtures/nginx_hpa.yaml").absolute()
+)
 
-        1. Deploy nginx with 1 replica
-        2. Start BridgeMount state machine
-        3. After shadow is created (PREPARING), scale original to 3
-        4. Verify the mount still reaches ACTIVE (shadow gets scaled to match)
-        """
-        from gefyra.bridge_mount_state import GefyraBridgeMount, GefyraBridgeMountObject
 
-        file_path = str(
-            Path(Path(__file__).parent.parent, "fixtures/nginx.yaml").absolute()
+def _make_bridge_mount(name: str, namespace: str):
+    from gefyra.bridge_mount_state import GefyraBridgeMount, GefyraBridgeMountObject
+
+    obj = GefyraBridgeMountObject(
+        data={
+            "apiVersion": "gefyra.dev/v1",
+            "metadata": {
+                "name": name,
+                "namespace": namespace,
+                "uid": "hpa-test-uid",
+                "resourceVersion": "123456",
+            },
+            "kind": "gefyrabridgemount",
+            "state": "REQUESTED",
+            "targetNamespace": namespace,
+            "target": "deploy/" + name,
+            "targetContainer": "nginx",
+            "provider": "carrier2mount",
+        }
+    )
+    obj._write_state = MagicMock()
+    return GefyraBridgeMount(
+        model=obj,
+        configuration=OperatorConfiguration(),
+        logger=logger,
+        initial="REQUESTED",
+    )
+
+
+async def _drive_to_active(bm) -> None:
+    """Walk the state machine forward until ACTIVE or retries exhausted."""
+    retries = 120
+    while retries > 0:
+        provider = bm.bridge_mount_provider
+        for attr in list(vars(provider)):
+            if attr.startswith("get_pods_workload_cache-") or attr.startswith(
+                "_get_workload_cache-"
+            ):
+                delattr(provider, attr)
+        try:
+            if bm.requested.is_active:
+                await bm.arrange()
+            elif bm.preparing.is_active:
+                await bm.install()
+            elif bm.installing.is_active:
+                await bm.install()
+            elif bm.active.is_active:
+                return
+        except TransitionNotAllowed:
+            retries -= 1
+        except Exception:
+            retries -= 1
+        sleep(3)
+
+
+class TestBridgeMountHPADuplication:
+    async def test_mount_duplicates_hpa(self, gefyra_crd: AClusterManager):
+        """With an HPA on the original deployment, the operator clones it to
+        target the shadow deployment. The original HPA stays untouched."""
+        name = "nginx-deployment"
+        namespace = "default"
+        original_hpa = "nginx-deployment-hpa"
+        duplicated_hpa = generate_duplicate_hpa_name(original_hpa)
+
+        gefyra_crd.apply(NGINX_FIXTURE)
+        gefyra_crd.wait(
+            "deployment/" + name,
+            "jsonpath='{.status.readyReplicas}'=1",
+            namespace=namespace,
+            timeout=120,
         )
-        gefyra_crd.apply(file_path)
+        gefyra_crd.apply(HPA_FIXTURE)
 
+        bm = _make_bridge_mount(name, namespace)
+        try:
+            await _drive_to_active(bm)
+            assert bm.active.is_active, (
+                f"BridgeMount should be ACTIVE but is {bm.current_state.value}"
+            )
+
+            # Duplicated HPA exists and points at the shadow workload.
+            duplicated = gefyra_crd.kubectl(
+                [
+                    "-n",
+                    namespace,
+                    "get",
+                    "hpa",
+                    duplicated_hpa,
+                    "-o",
+                    "json",
+                ]
+            )
+            assert (
+                duplicated["spec"]["scaleTargetRef"]["name"]
+                == name + "-gefyra"
+            )
+            assert duplicated["spec"]["scaleTargetRef"]["kind"] == "Deployment"
+
+            # Original HPA still targets the original deployment.
+            original = gefyra_crd.kubectl(
+                ["-n", namespace, "get", "hpa", original_hpa, "-o", "json"]
+            )
+            assert original["spec"]["scaleTargetRef"]["name"] == name
+        finally:
+            await bm.terminate()
+            gefyra_crd.wait(
+                "deployment/" + name + "-gefyra",
+                "delete",
+                namespace=namespace,
+                timeout=60,
+            )
+            gefyra_crd.wait(
+                "hpa/" + duplicated_hpa,
+                "delete",
+                namespace=namespace,
+                timeout=60,
+            )
+            # Original HPA must still be present.
+            gefyra_crd.kubectl(
+                ["-n", namespace, "get", "hpa", original_hpa]
+            )
+            gefyra_crd.kubectl(
+                ["-n", namespace, "delete", "hpa", original_hpa],
+                as_dict=False,
+            )
+        assert bm.terminated.is_active
+
+    async def test_mount_without_hpa_succeeds(self, gefyra_crd: AClusterManager):
+        """No HPA on the original → mount still reaches ACTIVE, no shadow HPA
+        is created, no errors raised."""
         name = "nginx-deployment"
         namespace = "default"
 
+        gefyra_crd.apply(NGINX_FIXTURE)
         gefyra_crd.wait(
             "deployment/" + name,
             "jsonpath='{.status.readyReplicas}'=1",
@@ -48,114 +171,26 @@ class TestBridgeMountHPAScale:
             timeout=120,
         )
 
-        bridge_mount_object = GefyraBridgeMountObject(
-            data={
-                "apiVersion": "gefyra.dev/v1",
-                "metadata": {
-                    "name": name,
-                    "namespace": namespace,
-                    "uid": "hpa-test-uid",
-                    "resourceVersion": "123456",
-                },
-                "kind": "gefyrabridgemount",
-                "state": "REQUESTED",
-                "targetNamespace": namespace,
-                "target": "deploy/" + name,
-                "targetContainer": "nginx",
-                "provider": "carrier2mount",
-            }
-        )
-        bridge_mount_object._write_state = MagicMock()
-        configuration = OperatorConfiguration()
+        bm = _make_bridge_mount(name, namespace)
+        try:
+            await _drive_to_active(bm)
+            assert bm.active.is_active
 
-        bm = GefyraBridgeMount(
-            model=bridge_mount_object,
-            configuration=configuration,
-            logger=logger,
-            initial="REQUESTED",
-        )
-        assert bm.requested.is_active
-
-        scaled = False
-        retries = 120
-        while retries > 0:
-            # Clear the provider's pod cache to simulate the real handler
-            # which creates a fresh provider instance on each invocation.
-            provider = bm.bridge_mount_provider
-            for attr in list(vars(provider)):
-                if attr.startswith("get_pods_workload_cache-") or attr.startswith(
-                    "_get_workload_cache-"
-                ):
-                    delattr(provider, attr)
-
-            print(bm)
-            try:
-                if bm.requested.is_active:
-                    await bm.arrange()
-                elif bm.preparing.is_active:
-                    # Scale original deployment after shadow was created
-                    if not scaled:
-                        logger.info(
-                            "Scaling original deployment to 3 replicas to simulate HPA"
-                        )
-                        gefyra_crd.kubectl(
-                            [
-                                "-n",
-                                namespace,
-                                "scale",
-                                "deployment/" + name,
-                                "--replicas=3",
-                            ],
-                            as_dict=False,
-                        )
-                        gefyra_crd.wait(
-                            "deployment/" + name,
-                            "jsonpath='{.status.readyReplicas}'=3",
-                            namespace=namespace,
-                            timeout=120,
-                        )
-                        scaled = True
-                        logger.info("Original deployment scaled to 3")
-                    await bm.install()
-                elif bm.installing.is_active:
-                    # Mirror the real handler: call install() (self-transition)
-                    # which triggers on_install → carrier install → activate
-                    await bm.install()
-                elif bm.active.is_active:
-                    break
-            except TransitionNotAllowed:
-                retries -= 1
-            except Exception:
-                print(f"TemporaryError {retries}")
-                retries -= 1
-
-            sleep(3)
-
-        assert bm.active.is_active, (
-            f"BridgeMount should be ACTIVE but is "
-            f"{bm.current_state.value} after scaling"
-        )
-
-        # Verify shadow has 3 replicas too
-        gefyra_crd.wait(
-            "deployment/" + name + "-gefyra",
-            "jsonpath='{.status.readyReplicas}'=3",
-            namespace=namespace,
-            timeout=120,
-        )
-
-        # Cleanup
-        await bm.terminate()
-        gefyra_crd.wait(
-            "deployment/" + name + "-gefyra",
-            "delete",
-            namespace=namespace,
-            timeout=60,
-        )
+            hpas = gefyra_crd.kubectl(
+                ["-n", namespace, "get", "hpa", "-o", "json"]
+            )
+            shadow_hpa_names = [
+                item["metadata"]["name"]
+                for item in hpas.get("items", [])
+                if item["metadata"]["name"].endswith("-gefyra")
+            ]
+            assert shadow_hpa_names == []
+        finally:
+            await bm.terminate()
+            gefyra_crd.wait(
+                "deployment/" + name + "-gefyra",
+                "delete",
+                namespace=namespace,
+                timeout=60,
+            )
         assert bm.terminated.is_active
-
-        # Scale back to 1 for other tests
-        gefyra_crd.kubectl(
-            ["-n", namespace, "scale", "deployment/" + name, "--replicas=1"],
-            as_dict=False,
-        )

--- a/operator/tests/unit/test_bridge_mount.py
+++ b/operator/tests/unit/test_bridge_mount.py
@@ -2,6 +2,7 @@ import json
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, DEFAULT, patch
 
+import kubernetes as k8s
 from kubernetes.client import V1Deployment, V1Probe
 
 import logging
@@ -118,6 +119,7 @@ class TestBridgeMountSync(TestCase):
 
 
 class TestBridgeMountObject(IsolatedAsyncioTestCase):
+    @patch("gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api")
     @patch.multiple(
         "gefyra.bridge_mount.carrier2mount",
         app=DEFAULT,
@@ -125,17 +127,29 @@ class TestBridgeMountObject(IsolatedAsyncioTestCase):
         custom_object_api=DEFAULT,
     )
     async def test_carrier_patch(
-        self, app, core_v1_api, custom_object_api
-    ):  # Made async
+        self, autoscaling_api, app, core_v1_api, custom_object_api
+    ):
+        from kubernetes.client import ApiException as _ApiExc
+
         from gefyra.bridge_mount.carrier2mount import Carrier2BridgeMount
 
-        app.read_namespaced_deployment.return_value = NginxDeploymentFactory()
+        def _read_deployment(name, namespace):
+            if name == "nginx":
+                return NginxDeploymentFactory()
+            # Shadow does not exist yet on first prepare().
+            raise _ApiExc(status=404)
+
+        app.read_namespaced_deployment.side_effect = _read_deployment
         pod = NginxPodFactory()
         core_v1_api.read_namespaced_pod_status.return_value = pod
         core_v1_api.list_namespaced_pod.return_value = V1PodListFactory(items=[pod])
         custom_object_api.get_namespaced_custom_object.return_value = {
             "target": "nginx-deployment",
         }
+        # No HPA on the source.
+        autoscaling_api.return_value.list_namespaced_horizontal_pod_autoscaler.return_value.items = (
+            []
+        )
 
         mount = Carrier2BridgeMount(
             name="test",
@@ -146,9 +160,19 @@ class TestBridgeMountObject(IsolatedAsyncioTestCase):
             post_event_function=post_event_noop,
             logger=logger,
         )
-        await mount.prepare()  # Await
-        app.read_namespaced_deployment.assert_called_once()
+        await mount.prepare()
+        # One read for the source, one for the (missing) shadow.
+        self.assertEqual(app.read_namespaced_deployment.call_count, 2)
         app.create_namespaced_deployment.assert_called_once()
+        # Hash annotation is persisted on the created shadow.
+        create_body = app.create_namespaced_deployment.call_args[0][1]
+        from gefyra.bridge_mount.carrier2mount.source_hash import (
+            SOURCE_WORKLOAD_HASH_ANNOTATION,
+        )
+
+        self.assertIn(
+            SOURCE_WORKLOAD_HASH_ANNOTATION, create_body.metadata.annotations
+        )
 
         app.reset_mock()
 
@@ -189,34 +213,44 @@ class TestBridgeMountObject(IsolatedAsyncioTestCase):
             "kubectl.kubernetes.io/restartedAt"
         ]
 
+    @patch("gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api")
     @patch.multiple(
         "gefyra.bridge_mount.carrier2mount",
         app=DEFAULT,
         core_v1_api=DEFAULT,
         custom_object_api=DEFAULT,
     )
-    async def test_duplicate_already_exists_patches(  # Made async
-        self, app, core_v1_api, custom_object_api
+    async def test_existing_shadow_without_hash_patches(
+        self, autoscaling_api, app, core_v1_api, custom_object_api
     ):
+        """When an existing shadow is found but carries no source-hash
+        annotation (legacy/foreign), the provider must patch it to catch up."""
         from gefyra.bridge_mount.carrier2mount import Carrier2BridgeMount
 
-        app.read_namespaced_deployment.return_value = NginxDeploymentFactory()
+        source = NginxDeploymentFactory()
+        legacy_shadow = NginxDeploymentFactory()
+        legacy_shadow.metadata.name = "nginx-gefyra"
+        # Simulate a pre-existing shadow without the new hash annotation.
+        legacy_shadow.metadata.annotations = None
+
+        def _read_deployment(name, namespace):
+            return source if name == "nginx" else legacy_shadow
+
+        app.read_namespaced_deployment.side_effect = _read_deployment
         pod = NginxPodFactory()
         core_v1_api.read_namespaced_pod_status.return_value = pod
         core_v1_api.list_namespaced_pod.return_value = V1PodListFactory(items=[pod])
         custom_object_api.get_namespaced_custom_object.return_value = {
             "target": "nginx-deployment",
         }
-        from gefyra.bridge_mount import carrier2mount as duplicate_mod
+        from kubernetes.client import ApiException as _ApiExc
 
-        app.create_namespaced_deployment.side_effect = duplicate_mod.ApiException(
-            status=409
-        )
         app.patch_namespaced_deployment.return_value = True
-        core_v1_api.create_namespaced_service.side_effect = duplicate_mod.ApiException(
-            status=409
-        )
+        core_v1_api.create_namespaced_service.side_effect = _ApiExc(status=409)
         core_v1_api.patch_namespaced_service.return_value = True
+        autoscaling_api.return_value.list_namespaced_horizontal_pod_autoscaler.return_value.items = (
+            []
+        )
 
         mount = Carrier2BridgeMount(
             name="test",
@@ -227,9 +261,66 @@ class TestBridgeMountObject(IsolatedAsyncioTestCase):
             post_event_function=post_event_noop,
             logger=logger,
         )
-        await mount.prepare()  # Await
+        await mount.prepare()
         app.patch_namespaced_deployment.assert_called_once()
+        # Replicas must not be overwritten on the patch — the shadow HPA owns it.
+        patch_body = app.patch_namespaced_deployment.call_args[1]["body"]
+        self.assertIsNone(patch_body.spec.replicas)
         core_v1_api.patch_namespaced_service.assert_called_once()
+        app.create_namespaced_deployment.assert_not_called()
+
+    @patch("gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api")
+    @patch.multiple(
+        "gefyra.bridge_mount.carrier2mount",
+        app=DEFAULT,
+        core_v1_api=DEFAULT,
+        custom_object_api=DEFAULT,
+    )
+    async def test_matching_source_hash_is_noop(
+        self, autoscaling_api, app, core_v1_api, custom_object_api
+    ):
+        """If the shadow already has the same source-hash annotation as the
+        current source, no apiserver write for the workload must happen."""
+        from gefyra.bridge_mount.carrier2mount import Carrier2BridgeMount
+        from gefyra.bridge_mount.carrier2mount.source_hash import (
+            SOURCE_WORKLOAD_HASH_ANNOTATION,
+            hash_workload_source,
+        )
+
+        source = NginxDeploymentFactory()
+        current_hash = hash_workload_source(source)
+
+        cached_shadow = NginxDeploymentFactory()
+        cached_shadow.metadata.name = "nginx-gefyra"
+        cached_shadow.metadata.annotations = {
+            SOURCE_WORKLOAD_HASH_ANNOTATION: current_hash,
+        }
+
+        def _read_deployment(name, namespace):
+            return source if name == "nginx" else cached_shadow
+
+        app.read_namespaced_deployment.side_effect = _read_deployment
+        custom_object_api.get_namespaced_custom_object.return_value = {
+            "target": "nginx-deployment",
+        }
+        autoscaling_api.return_value.list_namespaced_horizontal_pod_autoscaler.return_value.items = (
+            []
+        )
+
+        mount = Carrier2BridgeMount(
+            name="test",
+            configuration=OperatorConfiguration(),
+            target_namespace="default",
+            target="deploy/nginx",
+            target_container="nginx",
+            post_event_function=post_event_noop,
+            logger=logger,
+        )
+        await mount.prepare()
+        app.create_namespaced_deployment.assert_not_called()
+        app.patch_namespaced_deployment.assert_not_called()
+        core_v1_api.create_namespaced_service.assert_not_called()
+        core_v1_api.patch_namespaced_service.assert_not_called()
 
     @patch.multiple(
         "gefyra.bridge_mount.carrier2mount",

--- a/operator/tests/unit/test_bridge_mount.py
+++ b/operator/tests/unit/test_bridge_mount.py
@@ -2,7 +2,6 @@ import json
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import AsyncMock, DEFAULT, patch
 
-import kubernetes as k8s
 from kubernetes.client import V1Deployment, V1Probe
 
 import logging

--- a/operator/tests/unit/test_bridge_mount_hpa.py
+++ b/operator/tests/unit/test_bridge_mount_hpa.py
@@ -1,0 +1,305 @@
+import logging
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+logger = logging.getLogger(__name__)
+
+
+def _make_hpa(
+    name: str = "nginx-hpa",
+    target_kind: str = "Deployment",
+    target_name: str = "nginx-deployment",
+    labels: dict | None = None,
+    annotations: dict | None = None,
+):
+    from kubernetes.client import (
+        V1ObjectMeta,
+        V2CrossVersionObjectReference,
+        V2HorizontalPodAutoscaler,
+        V2HorizontalPodAutoscalerSpec,
+        V2HorizontalPodAutoscalerStatus,
+    )
+
+    return V2HorizontalPodAutoscaler(
+        metadata=V1ObjectMeta(
+            name=name,
+            namespace="default",
+            labels=labels or {"app": "nginx"},
+            annotations=annotations,
+            uid="orig-uid",
+            resource_version="42",
+            generation=3,
+        ),
+        spec=V2HorizontalPodAutoscalerSpec(
+            scale_target_ref=V2CrossVersionObjectReference(
+                api_version="apps/v1",
+                kind=target_kind,
+                name=target_name,
+            ),
+            min_replicas=1,
+            max_replicas=5,
+        ),
+        status=V2HorizontalPodAutoscalerStatus(
+            current_replicas=1,
+            desired_replicas=1,
+            conditions=[],
+        ),
+    )
+
+
+class TestGenerateDuplicateHpaName(TestCase):
+    def test_short_name_appends_suffix(self):
+        from gefyra.bridge_mount.utils import generate_duplicate_hpa_name
+
+        self.assertEqual(generate_duplicate_hpa_name("nginx"), "nginx-gefyra")
+
+    def test_long_name_truncates_to_63_chars(self):
+        from gefyra.bridge_mount.utils import generate_duplicate_hpa_name
+
+        long_name = "a" * 80
+        result = generate_duplicate_hpa_name(long_name)
+        self.assertLessEqual(len(result), 63)
+        self.assertTrue(result.endswith("-gefyra"))
+
+
+class TestCloneHpaForShadow(TestCase):
+    def test_clone_redirects_to_shadow_workload(self):
+        from gefyra.bridge_mount.carrier2mount.hpa import (
+            DUPLICATION_ID_LABEL,
+            clone_hpa_for_shadow,
+        )
+
+        original = _make_hpa(
+            annotations={
+                "kubectl.kubernetes.io/last-applied-configuration": "{}",
+                "autoscaling.alpha.kubernetes.io/metrics": "ignored",
+                "user.example.com/keep": "yes",
+            },
+        )
+        labels = {"app": "nginx-gefyra", DUPLICATION_ID_LABEL: "abc-123"}
+
+        cloned = clone_hpa_for_shadow(
+            original_hpa=original,
+            shadow_workload_name="nginx-deployment-gefyra",
+            duplication_labels=labels,
+        )
+
+        self.assertEqual(cloned.metadata.name, "nginx-hpa-gefyra")
+        self.assertEqual(
+            cloned.spec.scale_target_ref.name, "nginx-deployment-gefyra"
+        )
+        self.assertEqual(cloned.spec.scale_target_ref.kind, "Deployment")
+        self.assertEqual(cloned.metadata.labels, labels)
+        self.assertIsNone(cloned.metadata.uid)
+        self.assertIsNone(cloned.metadata.resource_version)
+        self.assertIsNone(cloned.metadata.generation)
+        self.assertIsNone(cloned.status)
+        self.assertIn("user.example.com/keep", cloned.metadata.annotations)
+        self.assertNotIn(
+            "kubectl.kubernetes.io/last-applied-configuration",
+            cloned.metadata.annotations,
+        )
+        self.assertNotIn(
+            "autoscaling.alpha.kubernetes.io/metrics",
+            cloned.metadata.annotations,
+        )
+        # Original is not mutated
+        self.assertEqual(original.metadata.uid, "orig-uid")
+        self.assertEqual(original.spec.scale_target_ref.name, "nginx-deployment")
+
+
+class TestFindHpaForTarget(TestCase):
+    def test_returns_match(self):
+        from kubernetes.client import V2HorizontalPodAutoscalerList
+
+        with patch(
+            "gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api"
+        ) as mock_api:
+            from gefyra.bridge_mount.carrier2mount.hpa import find_hpa_for_target
+
+            match = _make_hpa()
+            mock_api.return_value.list_namespaced_horizontal_pod_autoscaler.return_value = (
+                V2HorizontalPodAutoscalerList(items=[match])
+            )
+            result = find_hpa_for_target(
+                "default", "Deployment", "nginx-deployment", logger
+            )
+            self.assertIs(result, match)
+
+    def test_returns_none_when_no_match(self):
+        from kubernetes.client import V2HorizontalPodAutoscalerList
+
+        with patch(
+            "gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api"
+        ) as mock_api:
+            from gefyra.bridge_mount.carrier2mount.hpa import find_hpa_for_target
+
+            mock_api.return_value.list_namespaced_horizontal_pod_autoscaler.return_value = (
+                V2HorizontalPodAutoscalerList(
+                    items=[_make_hpa(target_name="other")]
+                )
+            )
+            self.assertIsNone(
+                find_hpa_for_target(
+                    "default", "Deployment", "nginx-deployment", logger
+                )
+            )
+
+    def test_kind_match_is_case_insensitive(self):
+        from kubernetes.client import V2HorizontalPodAutoscalerList
+
+        with patch(
+            "gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api"
+        ) as mock_api:
+            from gefyra.bridge_mount.carrier2mount.hpa import find_hpa_for_target
+
+            match = _make_hpa(target_kind="deployment")
+            mock_api.return_value.list_namespaced_horizontal_pod_autoscaler.return_value = (
+                V2HorizontalPodAutoscalerList(items=[match])
+            )
+            result = find_hpa_for_target(
+                "default", "Deployment", "nginx-deployment", logger
+            )
+            self.assertIs(result, match)
+
+    def test_multiple_matches_warns_and_returns_first(self):
+        from kubernetes.client import V2HorizontalPodAutoscalerList
+
+        with patch(
+            "gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api"
+        ) as mock_api:
+            from gefyra.bridge_mount.carrier2mount.hpa import find_hpa_for_target
+
+            first = _make_hpa(name="hpa-a")
+            second = _make_hpa(name="hpa-b")
+            mock_api.return_value.list_namespaced_horizontal_pod_autoscaler.return_value = (
+                V2HorizontalPodAutoscalerList(items=[first, second])
+            )
+            warn_logger = MagicMock()
+            result = find_hpa_for_target(
+                "default", "Deployment", "nginx-deployment", warn_logger
+            )
+            self.assertIs(result, first)
+            warn_logger.warning.assert_called_once()
+
+    def test_api_error_returns_none(self):
+        from kubernetes.client import ApiException
+
+        with patch(
+            "gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api"
+        ) as mock_api:
+            from gefyra.bridge_mount.carrier2mount.hpa import find_hpa_for_target
+
+            mock_api.return_value.list_namespaced_horizontal_pod_autoscaler.side_effect = (
+                ApiException(status=403, reason="Forbidden")
+            )
+            warn_logger = MagicMock()
+            result = find_hpa_for_target(
+                "default", "Deployment", "nginx-deployment", warn_logger
+            )
+            self.assertIsNone(result)
+            warn_logger.warning.assert_called_once()
+
+
+class TestApplyClonedHpa(TestCase):
+    def test_create_path(self):
+        with patch(
+            "gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api"
+        ) as mock_api:
+            from gefyra.bridge_mount.carrier2mount.hpa import apply_cloned_hpa
+
+            cloned = _make_hpa(name="nginx-hpa-gefyra")
+            apply_cloned_hpa("default", cloned)
+            mock_api.return_value.create_namespaced_horizontal_pod_autoscaler.assert_called_once_with(
+                namespace="default", body=cloned
+            )
+
+    def test_409_falls_back_to_patch(self):
+        from kubernetes.client import ApiException
+
+        with patch(
+            "gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api"
+        ) as mock_api:
+            from gefyra.bridge_mount.carrier2mount.hpa import apply_cloned_hpa
+
+            cloned = _make_hpa(name="nginx-hpa-gefyra")
+            api = mock_api.return_value
+            api.create_namespaced_horizontal_pod_autoscaler.side_effect = (
+                ApiException(status=409)
+            )
+            apply_cloned_hpa("default", cloned)
+            api.patch_namespaced_horizontal_pod_autoscaler.assert_called_once_with(
+                name="nginx-hpa-gefyra", namespace="default", body=cloned
+            )
+
+
+class TestDeleteDuplicatedHpa(TestCase):
+    def test_delete_by_name_then_label_sweep(self):
+        from kubernetes.client import V2HorizontalPodAutoscalerList
+
+        with patch(
+            "gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api"
+        ) as mock_api:
+            from gefyra.bridge_mount.carrier2mount.hpa import (
+                DUPLICATION_ID_LABEL,
+                delete_duplicated_hpa,
+            )
+
+            api = mock_api.return_value
+            api.list_namespaced_horizontal_pod_autoscaler.return_value = (
+                V2HorizontalPodAutoscalerList(items=[])
+            )
+            delete_duplicated_hpa("default", "nginx-hpa", "abc-123", logger)
+            api.delete_namespaced_horizontal_pod_autoscaler.assert_called_once_with(
+                name="nginx-hpa-gefyra", namespace="default"
+            )
+            api.list_namespaced_horizontal_pod_autoscaler.assert_called_once_with(
+                namespace="default",
+                label_selector=f"{DUPLICATION_ID_LABEL}=abc-123",
+            )
+
+    def test_404_on_direct_delete_is_ignored(self):
+        from kubernetes.client import ApiException, V2HorizontalPodAutoscalerList
+
+        with patch(
+            "gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api"
+        ) as mock_api:
+            from gefyra.bridge_mount.carrier2mount.hpa import delete_duplicated_hpa
+
+            api = mock_api.return_value
+            api.delete_namespaced_horizontal_pod_autoscaler.side_effect = (
+                ApiException(status=404)
+            )
+            api.list_namespaced_horizontal_pod_autoscaler.return_value = (
+                V2HorizontalPodAutoscalerList(items=[])
+            )
+            delete_duplicated_hpa("default", "nginx-hpa", "abc-123", logger)
+
+    def test_label_sweep_deletes_leftovers(self):
+        from kubernetes.client import V2HorizontalPodAutoscalerList
+
+        with patch(
+            "gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api"
+        ) as mock_api:
+            from gefyra.bridge_mount.carrier2mount.hpa import delete_duplicated_hpa
+
+            api = mock_api.return_value
+            leftover = _make_hpa(name="leftover-gefyra")
+            api.list_namespaced_horizontal_pod_autoscaler.return_value = (
+                V2HorizontalPodAutoscalerList(items=[leftover])
+            )
+            delete_duplicated_hpa("default", None, "abc-123", logger)
+            api.delete_namespaced_horizontal_pod_autoscaler.assert_called_once_with(
+                name="leftover-gefyra", namespace="default"
+            )
+
+    def test_no_duplication_id_skips_label_sweep(self):
+        with patch(
+            "gefyra.bridge_mount.carrier2mount.hpa._autoscaling_api"
+        ) as mock_api:
+            from gefyra.bridge_mount.carrier2mount.hpa import delete_duplicated_hpa
+
+            api = mock_api.return_value
+            delete_duplicated_hpa("default", "nginx-hpa", None, logger)
+            api.list_namespaced_horizontal_pod_autoscaler.assert_not_called()

--- a/operator/tests/unit/test_bridge_mount_state.py
+++ b/operator/tests/unit/test_bridge_mount_state.py
@@ -286,24 +286,24 @@ class TestBridgeMountRestoreFromInstalling(IsolatedAsyncioTestCase):
             await bm.send("restore")
 
 
-class TestBridgeMountHPAScaleScenario(IsolatedAsyncioTestCase):
-    """Test that HPA scaling triggers shadow scaling instead of restore loops."""
+class TestBridgeMountReplicaSyncRemoved(IsolatedAsyncioTestCase):
+    """After GO-1030, the operator no longer follows the original deployment's
+    replica count. The duplicated HPA owns the shadow's scaling decisions, so
+    prepared()/ready() must not react to replica mismatches."""
 
-    async def test_replica_mismatch_scales_shadow_from_installing(self):
-        """Simulate HPA downscale: original has 1 pod, shadow still has 2.
+    def test_scale_shadow_to_match_helper_is_gone(self):
+        from gefyra.bridge_mount.carrier2mount import Carrier2BridgeMount
 
-        prepared() should scale the shadow to match and return False so the
-        handler retries after pods have converged.
-        """
+        assert not hasattr(Carrier2BridgeMount, "_scale_shadow_to_match")
+
+    async def test_prepared_ignores_replica_mismatch(self):
+        """Original has 1 pod, shadow has 2 ready pods. prepared() returns True
+        and no scaling helper is invoked."""
         from tests.factories import NginxPodFactory, V1PodListFactory
 
-        # Original workload: HPA scaled down to 1 pod
         original_pods = V1PodListFactory(
-            items=[
-                NginxPodFactory(metadata__name="nginx-original-1"),
-            ]
+            items=[NginxPodFactory(metadata__name="nginx-original-1")]
         )
-        # Shadow workload: still has 2 pods from before HPA
         gefyra_pods = V1PodListFactory(
             items=[
                 NginxPodFactory(metadata__name="nginx-gefyra-1"),
@@ -313,73 +313,88 @@ class TestBridgeMountHPAScaleScenario(IsolatedAsyncioTestCase):
 
         bm = _make_bridge_mount(state="INSTALLING")
         provider = bm.bridge_mount_provider
-
         original_target = "deploy/nginx"
 
         async def mock_get_pods(name, namespace):
             if name == original_target:
                 return original_pods
             return gefyra_pods
-
-        provider.get_pods_workload = mock_get_pods
-        provider._scale_shadow_to_match = AsyncMock()
-
-        is_prepared = await provider.prepared()
-        assert is_prepared is False
-        provider._scale_shadow_to_match.assert_awaited_once_with(1)
-
-    async def test_replica_mismatch_scales_shadow_from_preparing(self):
-        """Same scenario but starting from PREPARING state."""
-        from tests.factories import NginxPodFactory, V1PodListFactory
-
-        original_pods = V1PodListFactory(
-            items=[
-                NginxPodFactory(metadata__name="nginx-original-1"),
-            ]
-        )
-        gefyra_pods = V1PodListFactory(
-            items=[
-                NginxPodFactory(metadata__name="nginx-gefyra-1"),
-                NginxPodFactory(metadata__name="nginx-gefyra-2"),
-            ]
-        )
-
-        bm = _make_bridge_mount(state="PREPARING")
-        provider = bm.bridge_mount_provider
-
-        original_target = "deploy/nginx"
-
-        async def mock_get_pods(name, namespace):
-            if name == original_target:
-                return original_pods
-            return gefyra_pods
-
-        provider.get_pods_workload = mock_get_pods
-        provider._scale_shadow_to_match = AsyncMock()
-
-        is_prepared = await provider.prepared()
-        assert is_prepared is False
-        provider._scale_shadow_to_match.assert_awaited_once_with(1)
-
-    async def test_matching_replicas_prepared_returns_true(self):
-        """When pod counts match and pods are ready, prepared() returns True."""
-        from tests.factories import NginxPodFactory, V1PodListFactory
-
-        pod = NginxPodFactory(metadata__name="nginx-1")
-        pod_list = V1PodListFactory(items=[pod])
-
-        bm = _make_bridge_mount(state="INSTALLING")
-        provider = bm.bridge_mount_provider
-
-        async def mock_get_pods(name, namespace):
-            return pod_list
-
-        provider.get_pods_workload = mock_get_pods
 
         async def mock_healthy(pod, container_name):
             return True
 
+        provider.get_pods_workload = mock_get_pods
         provider.pod_ready_and_healthy = mock_healthy
 
         result = await provider.prepared()
         assert result is True
+
+    async def test_prepared_returns_false_when_shadow_pods_not_ready(self):
+        from tests.factories import NginxPodFactory, V1PodListFactory
+
+        gefyra_pods = V1PodListFactory(
+            items=[NginxPodFactory(metadata__name="nginx-gefyra-1")]
+        )
+
+        bm = _make_bridge_mount(state="INSTALLING")
+        provider = bm.bridge_mount_provider
+
+        async def mock_get_pods(name, namespace):
+            return gefyra_pods
+
+        async def mock_healthy(pod, container_name):
+            return False
+
+        provider.get_pods_workload = mock_get_pods
+        provider.pod_ready_and_healthy = mock_healthy
+
+        result = await provider.prepared()
+        assert result is False
+
+    async def test_ready_ignores_replica_mismatch(self):
+        from tests.factories import NginxPodFactory, V1PodListFactory
+
+        original_pods = V1PodListFactory(
+            items=[NginxPodFactory(metadata__name="nginx-original-1")]
+        )
+        gefyra_pods = V1PodListFactory(
+            items=[
+                NginxPodFactory(metadata__name="nginx-gefyra-1"),
+                NginxPodFactory(metadata__name="nginx-gefyra-2"),
+            ]
+        )
+
+        bm = _make_bridge_mount(state="ACTIVE")
+        provider = bm.bridge_mount_provider
+        original_target = "deploy/nginx"
+
+        async def mock_get_pods(name, namespace):
+            if name == original_target:
+                return original_pods
+            return gefyra_pods
+
+        async def mock_healthy(pod, container_name):
+            return True
+
+        provider.get_pods_workload = mock_get_pods
+        provider.pod_ready_and_healthy = mock_healthy
+
+        with patch.object(
+            type(provider),
+            "_carrier_installed",
+            new=_async_property(True),
+        ), patch.object(
+            type(provider),
+            "_upstream_set",
+            new=_async_property(True),
+        ):
+            assert await provider.ready() is True
+
+
+def _async_property(value):
+    """Build an awaitable property descriptor returning ``value``."""
+
+    async def _coro(_self):
+        return value
+
+    return property(_coro)

--- a/operator/tests/unit/test_source_hash.py
+++ b/operator/tests/unit/test_source_hash.py
@@ -1,0 +1,142 @@
+from copy import deepcopy
+from unittest import TestCase
+
+
+def _make_deployment():
+    from kubernetes.client import (
+        V1Container,
+        V1ContainerPort,
+        V1Deployment,
+        V1DeploymentSpec,
+        V1EnvVar,
+        V1LabelSelector,
+        V1ObjectMeta,
+        V1PodSpec,
+        V1PodTemplateSpec,
+    )
+
+    return V1Deployment(
+        metadata=V1ObjectMeta(name="nginx", labels={"app": "nginx"}),
+        spec=V1DeploymentSpec(
+            replicas=1,
+            selector=V1LabelSelector(match_labels={"app": "nginx"}),
+            template=V1PodTemplateSpec(
+                metadata=V1ObjectMeta(labels={"app": "nginx"}),
+                spec=V1PodSpec(
+                    containers=[
+                        V1Container(
+                            name="nginx",
+                            image="nginx:1.27",
+                            ports=[V1ContainerPort(container_port=80)],
+                            env=[V1EnvVar(name="LOG_LEVEL", value="info")],
+                        )
+                    ]
+                ),
+            ),
+        ),
+    )
+
+
+def _make_hpa(target_name="nginx", min_replicas=1, max_replicas=5):
+    from kubernetes.client import (
+        V1ObjectMeta,
+        V2CrossVersionObjectReference,
+        V2HorizontalPodAutoscaler,
+        V2HorizontalPodAutoscalerSpec,
+    )
+
+    return V2HorizontalPodAutoscaler(
+        metadata=V1ObjectMeta(name="hpa", namespace="default"),
+        spec=V2HorizontalPodAutoscalerSpec(
+            scale_target_ref=V2CrossVersionObjectReference(
+                api_version="apps/v1", kind="Deployment", name=target_name
+            ),
+            min_replicas=min_replicas,
+            max_replicas=max_replicas,
+        ),
+    )
+
+
+class TestWorkloadHash(TestCase):
+    def test_identical_deployments_hash_identically(self):
+        from gefyra.bridge_mount.carrier2mount.source_hash import hash_workload_source
+
+        a = _make_deployment()
+        b = _make_deployment()
+        self.assertEqual(hash_workload_source(a), hash_workload_source(b))
+
+    def test_replica_change_does_not_change_hash(self):
+        """HPA-driven replica changes on the source must not trigger shadow
+        churn, so the hash ignores spec.replicas."""
+        from gefyra.bridge_mount.carrier2mount.source_hash import hash_workload_source
+
+        a = _make_deployment()
+        b = deepcopy(a)
+        b.spec.replicas = 42
+        self.assertEqual(hash_workload_source(a), hash_workload_source(b))
+
+    def test_image_change_changes_hash(self):
+        from gefyra.bridge_mount.carrier2mount.source_hash import hash_workload_source
+
+        a = _make_deployment()
+        b = deepcopy(a)
+        b.spec.template.spec.containers[0].image = "nginx:1.28"
+        self.assertNotEqual(hash_workload_source(a), hash_workload_source(b))
+
+    def test_env_change_changes_hash(self):
+        from gefyra.bridge_mount.carrier2mount.source_hash import hash_workload_source
+
+        a = _make_deployment()
+        b = deepcopy(a)
+        b.spec.template.spec.containers[0].env[0].value = "debug"
+        self.assertNotEqual(hash_workload_source(a), hash_workload_source(b))
+
+    def test_volatile_metadata_does_not_change_hash(self):
+        from gefyra.bridge_mount.carrier2mount.source_hash import hash_workload_source
+
+        a = _make_deployment()
+        b = deepcopy(a)
+        # These fields get set/bumped by the apiserver on every read and must
+        # not affect the logical "what is this workload" hash.
+        b.metadata.resource_version = "999"
+        b.metadata.uid = "fresh-uid"
+        b.metadata.generation = 17
+        self.assertEqual(hash_workload_source(a), hash_workload_source(b))
+
+    def test_hash_is_stable_string(self):
+        from gefyra.bridge_mount.carrier2mount.source_hash import hash_workload_source
+
+        h = hash_workload_source(_make_deployment())
+        self.assertIsInstance(h, str)
+        self.assertEqual(len(h), 64)  # sha256 hex
+
+
+class TestHpaHash(TestCase):
+    def test_identical_hpas_hash_identically(self):
+        from gefyra.bridge_mount.carrier2mount.source_hash import hash_hpa_source
+
+        self.assertEqual(hash_hpa_source(_make_hpa()), hash_hpa_source(_make_hpa()))
+
+    def test_scale_target_name_is_ignored(self):
+        """The duplicated HPA always retargets the shadow workload — so the
+        source-hash must ignore scaleTargetRef.name, else the hash would
+        always mismatch between original and duplicate."""
+        from gefyra.bridge_mount.carrier2mount.source_hash import hash_hpa_source
+
+        a = _make_hpa(target_name="nginx")
+        b = _make_hpa(target_name="nginx-gefyra")
+        self.assertEqual(hash_hpa_source(a), hash_hpa_source(b))
+
+    def test_min_replicas_change_changes_hash(self):
+        from gefyra.bridge_mount.carrier2mount.source_hash import hash_hpa_source
+
+        a = _make_hpa(min_replicas=1)
+        b = _make_hpa(min_replicas=3)
+        self.assertNotEqual(hash_hpa_source(a), hash_hpa_source(b))
+
+    def test_max_replicas_change_changes_hash(self):
+        from gefyra.bridge_mount.carrier2mount.source_hash import hash_hpa_source
+
+        a = _make_hpa(max_replicas=5)
+        b = _make_hpa(max_replicas=10)
+        self.assertNotEqual(hash_hpa_source(a), hash_hpa_source(b))

--- a/testing/stress/idempotency_driver.py
+++ b/testing/stress/idempotency_driver.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""GO-1030 idempotency stress driver — operator-free.
+
+Drives ``Carrier2BridgeMount._duplicate_workload()`` directly against a real
+cluster workload and verifies that the shadow deployment and its duplicated
+HPA never drift. Any drift (resourceVersion bump, pod UID change, container
+restart, HPA spec change) would mean the idempotency layer is broken and
+slow-starting workloads (JVM apps etc.) would suffer a rolling restart on
+every operator reconciliation.
+
+Unlike a real-operator stress test, this driver does not depend on a running
+Gefyra operator — so it works even when Stowaway can't come up on a given
+host. It calls the provider's duplication method N times in a tight loop
+(default 20 × 1s); the operator-timer equivalent would be 20 × 60s.
+
+Usage:
+    # deploy a workload (+ HPA optional), then point the driver at it:
+    kubectl apply -f operator/tests/fixtures/nginx.yaml
+    kubectl apply -f operator/tests/fixtures/nginx_hpa.yaml   # optional
+    ./idempotency_driver.py --target deploy/nginx-deployment --container nginx
+    ./idempotency_driver.py --iterations 50 --interval 0.5
+
+Prereqs:
+    - kubeconfig for the target cluster is active
+    - the workload (+ HPA, optional) is already applied and ready
+    - PYTHONPATH includes the operator/ directory (the script adds it itself)
+
+Exits 0 on success, 1 on drift, 2 on setup error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "operator"))
+
+import kubernetes  # noqa: E402
+
+
+async def _noop_event(*_args, **_kwargs) -> None:
+    return None
+
+
+def _make_logger() -> logging.Logger:
+    log = logging.getLogger("gefyra.stress")
+    log.setLevel(logging.INFO)
+    if not log.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            logging.Formatter("[%(asctime)s] %(message)s", datefmt="%H:%M:%S")
+        )
+        log.addHandler(handler)
+    log.propagate = False
+    return log
+
+
+def _snapshot_shadow(apps, core, target_name: str, namespace: str) -> dict:
+    d = apps.read_namespaced_deployment(f"{target_name}-gefyra", namespace)
+    pods = core.list_namespaced_pod(
+        namespace,
+        label_selector=f"app={target_name}-gefyra",
+    )
+    pod_state = sorted(
+        (
+            p.metadata.uid,
+            (p.status.container_statuses[0].restart_count
+             if p.status.container_statuses else 0),
+        )
+        for p in pods.items
+    )
+    return {
+        "rv": d.metadata.resource_version,
+        "uid": d.metadata.uid,
+        "pods": pod_state,
+    }
+
+
+def _snapshot_hpa(autoscaling, shadow_hpa_name: str, namespace: str) -> dict:
+    h = autoscaling.read_namespaced_horizontal_pod_autoscaler(
+        shadow_hpa_name, namespace
+    )
+    return {
+        "rv": h.metadata.resource_version,
+        "target": h.spec.scale_target_ref.name,
+        "min": h.spec.min_replicas,
+        "max": h.spec.max_replicas,
+    }
+
+
+def _discover_shadow_hpa(autoscaling, namespace: str) -> str | None:
+    hpas = autoscaling.list_namespaced_horizontal_pod_autoscaler(namespace)
+    for h in hpas.items:
+        if h.metadata.name.endswith("-gefyra"):
+            return h.metadata.name
+    return None
+
+
+async def run(args) -> int:
+    log = _make_logger()
+    kubernetes.config.load_kube_config()
+
+    # Imports deferred until after sys.path + kubeconfig are set up.
+    from gefyra.bridge_mount.carrier2mount import Carrier2BridgeMount
+    from gefyra.configuration import OperatorConfiguration
+
+    provider = Carrier2BridgeMount(
+        name="idempotency-stress",
+        configuration=OperatorConfiguration(),
+        target_namespace=args.namespace,
+        target=args.target,
+        target_container=args.container,
+        post_event_function=_noop_event,
+        logger=log,
+    )
+
+    apps = kubernetes.client.AppsV1Api()
+    core = kubernetes.client.CoreV1Api()
+    autoscaling = kubernetes.client.AutoscalingV2Api()
+    target_name = args.target.split("/", 1)[1]
+    shadow_name = f"{target_name}-gefyra"
+
+    log.info(f"initial prepare() for {args.target} → {shadow_name}")
+    try:
+        await provider.prepare()
+    except Exception as e:
+        log.error(f"prepare() failed: {e}")
+        return 2
+
+    log.info("waiting for shadow deployment to become ready…")
+    for _ in range(args.ready_timeout // 2):
+        try:
+            d = apps.read_namespaced_deployment_status(shadow_name, args.namespace)
+        except kubernetes.client.ApiException as e:
+            log.warning(f"shadow deployment not visible yet: {e.reason}")
+            await asyncio.sleep(2)
+            continue
+        desired = d.spec.replicas or 1
+        ready = d.status.ready_replicas or 0
+        if ready >= desired:
+            break
+        await asyncio.sleep(2)
+    else:
+        log.error(f"shadow deployment did not become ready within "
+                  f"{args.ready_timeout}s")
+        return 2
+
+    shadow_hpa_name = _discover_shadow_hpa(autoscaling, args.namespace)
+    if shadow_hpa_name:
+        log.info(f"duplicated HPA found: {shadow_hpa_name}")
+    else:
+        log.info("no duplicated HPA detected — running workload-only scenario")
+
+    baseline_shadow = _snapshot_shadow(apps, core, target_name, args.namespace)
+    baseline_hpa = (
+        _snapshot_hpa(autoscaling, shadow_hpa_name, args.namespace)
+        if shadow_hpa_name
+        else None
+    )
+    log.info(f"baseline shadow: {baseline_shadow}")
+    if baseline_hpa:
+        log.info(f"baseline HPA:    {baseline_hpa}")
+
+    drift = 0
+    for i in range(1, args.iterations + 1):
+        await asyncio.sleep(args.interval)
+        try:
+            await provider._duplicate_workload()
+        except Exception as e:
+            log.error(f"iteration {i}: _duplicate_workload raised: {e}")
+            drift += 1
+            continue
+
+        cur_shadow = _snapshot_shadow(apps, core, target_name, args.namespace)
+        cur_hpa = (
+            _snapshot_hpa(autoscaling, shadow_hpa_name, args.namespace)
+            if shadow_hpa_name
+            else None
+        )
+
+        if cur_shadow != baseline_shadow:
+            log.error(
+                f"iteration {i}: SHADOW DRIFT\n"
+                f"  baseline={baseline_shadow}\n"
+                f"  current ={cur_shadow}"
+            )
+            drift += 1
+        elif cur_hpa != baseline_hpa:
+            log.error(
+                f"iteration {i}: HPA DRIFT\n"
+                f"  baseline={baseline_hpa}\n"
+                f"  current ={cur_hpa}"
+            )
+            drift += 1
+        else:
+            log.info(
+                f"iteration {i}/{args.iterations}: stable "
+                f"(shadow rv={cur_shadow['rv']}, "
+                f"hpa rv={cur_hpa['rv'] if cur_hpa else '-'})"
+            )
+
+    if not args.skip_cleanup:
+        log.info("cleanup: uninstall()")
+        try:
+            await provider.uninstall()
+        except Exception as e:
+            log.warning(f"uninstall failed (non-fatal): {e}")
+
+    if drift:
+        log.error(f"FAIL: drift observed in {drift} iteration(s)")
+        return 1
+    log.info(f"OK: {args.iterations} reconcile calls against real cluster, no drift")
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--target", default="deploy/nginx-deployment",
+                   help="K8s workload reference (deploy/NAME or sts/NAME)")
+    p.add_argument("--namespace", default="default")
+    p.add_argument("--container", default="nginx",
+                   help="container name inside the target pod")
+    p.add_argument("--iterations", type=int, default=20)
+    p.add_argument("--interval", type=float, default=1.0,
+                   help="seconds between _duplicate_workload() calls")
+    p.add_argument("--ready-timeout", type=int, default=240,
+                   help="seconds to wait for the shadow to become ready")
+    p.add_argument("--skip-cleanup", action="store_true",
+                   help="leave the shadow deployment in place after the run")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(run(_parse_args())))

--- a/testing/stress/idempotency_stress.sh
+++ b/testing/stress/idempotency_stress.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# GO-1030 idempotency stress-test.
+#
+# Verifies that repeated operator reconciliations do NOT:
+#   - bump the shadow deployment's resourceVersion (= no apiserver write)
+#   - rotate shadow pods (same pod UIDs, same restart count)
+#   - change the duplicated HPA's spec
+#
+# Prerequisite: a Gefyra operator is running, the source workload + (optional)
+# HPA are deployed, and a GefyraBridgeMount targeting the workload has reached
+# ACTIVE state. By default the script targets the nginx fixture from
+# operator/tests/fixtures/nginx.yaml + nginx_hpa.yaml — override via the env
+# variables below for any other workload.
+#
+#   testing/stress/idempotency_stress.sh [--iterations N] [--interval SECONDS]
+#
+# Defaults: 5 iterations, 70 seconds apart (operator reconcile loop runs
+# every 60s; 70s makes sure we observe at least one full cycle).
+#
+# Override the targeted resources via env vars:
+#   NS=default SHADOW=foo-gefyra ORIGINAL_HPA=foo-hpa SHADOW_HPA=foo-hpa-gefyra \
+#     testing/stress/idempotency_stress.sh
+#
+# Exits non-zero on any drift.
+
+set -euo pipefail
+
+NS="${NS:-default}"
+SHADOW="${SHADOW:-nginx-deployment-gefyra}"
+ORIGINAL_HPA="${ORIGINAL_HPA:-nginx-deployment-hpa}"
+SHADOW_HPA="${SHADOW_HPA:-nginx-deployment-hpa-gefyra}"
+
+iterations=5
+interval=70
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --iterations) iterations="$2"; shift 2 ;;
+    --interval)   interval="$2";   shift 2 ;;
+    -h|--help)
+      sed -n '2,18p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '%s %s\n' "[$(date -u +%H:%M:%S)]" "$*"; }
+
+snapshot() {
+  local kind="$1" name="$2" jsonpath="$3"
+  kubectl -n "$NS" get "$kind" "$name" -o jsonpath="$jsonpath" 2>/dev/null
+}
+
+shadow_snapshot() {
+  # "<rv>|<uid>|<podUid1>:<restart1>,<podUid2>:<restart2>,..."
+  local rv uid pods
+  rv=$(snapshot deploy "$SHADOW" '{.metadata.resourceVersion}')
+  uid=$(snapshot deploy "$SHADOW" '{.metadata.uid}')
+  pods=$(kubectl -n "$NS" get pods \
+    -l "app=$(snapshot deploy "$SHADOW" '{.spec.selector.matchLabels.app}')" \
+    -o jsonpath='{range .items[*]}{.metadata.uid}:{.status.containerStatuses[0].restartCount},{end}' \
+    2>/dev/null || true)
+  printf '%s|%s|%s' "$rv" "$uid" "$pods"
+}
+
+hpa_snapshot() {
+  # "<rv>|<scaleTargetName>|<min>|<max>"
+  local rv target min max
+  rv=$(snapshot hpa "$SHADOW_HPA" '{.metadata.resourceVersion}')
+  target=$(snapshot hpa "$SHADOW_HPA" '{.spec.scaleTargetRef.name}')
+  min=$(snapshot hpa "$SHADOW_HPA" '{.spec.minReplicas}')
+  max=$(snapshot hpa "$SHADOW_HPA" '{.spec.maxReplicas}')
+  printf '%s|%s|%s|%s' "$rv" "$target" "$min" "$max"
+}
+
+if ! kubectl -n "$NS" get deploy "$SHADOW" >/dev/null 2>&1; then
+  echo "Shadow deployment '$SHADOW' not found in namespace '$NS'." >&2
+  echo "Apply testing/workloads/slow_java_stress.yaml first and wait for ACTIVE." >&2
+  exit 2
+fi
+
+baseline_shadow=$(shadow_snapshot)
+baseline_hpa=$(hpa_snapshot || true)
+
+log "baseline shadow   : $baseline_shadow"
+log "baseline shadow HPA: ${baseline_hpa:-<not present>}"
+
+fail=0
+for i in $(seq 1 "$iterations"); do
+  log "iteration $i/$iterations — waiting ${interval}s for reconcile tick"
+  sleep "$interval"
+
+  current_shadow=$(shadow_snapshot)
+  if [[ "$current_shadow" != "$baseline_shadow" ]]; then
+    log "DRIFT in shadow deployment:"
+    log "  baseline: $baseline_shadow"
+    log "  current : $current_shadow"
+    fail=1
+  else
+    log "shadow stable (rv=${baseline_shadow%%|*})"
+  fi
+
+  if [[ -n "$baseline_hpa" ]]; then
+    current_hpa=$(hpa_snapshot)
+    if [[ "$current_hpa" != "$baseline_hpa" ]]; then
+      log "DRIFT in duplicated HPA:"
+      log "  baseline: $baseline_hpa"
+      log "  current : $current_hpa"
+      fail=1
+    else
+      log "shadow HPA stable (rv=${baseline_hpa%%|*})"
+    fi
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  log "FAIL: drift observed during reconciliations — idempotency broken"
+  exit 1
+fi
+
+log "OK: $iterations reconcile ticks, no drift on shadow or HPA."

--- a/testing/workloads/nginx_hpa.yaml
+++ b/testing/workloads/nginx_hpa.yaml
@@ -1,0 +1,100 @@
+# Manual test bundle for GO-1030 (HPA duplication for shadow deployments).
+#
+# Apply this manifest to a cluster that already has the Gefyra operator
+# running (e.g. via `gefyra up`). The operator will then duplicate the HPA
+# onto the shadow workload.
+#
+#   kubectl apply -f testing/workloads/nginx_hpa.yaml
+#
+# Verify (after a few seconds):
+#   kubectl get hpa
+#     NAME                          REFERENCE                          MINPODS   MAXPODS
+#     nginx-deployment-hpa          Deployment/nginx-deployment        1         5
+#     nginx-deployment-hpa-gefyra   Deployment/nginx-deployment-gefyra 1         5
+#   kubectl get deploy
+#     nginx-deployment           1/1   running carrier2 (lightweight)
+#     nginx-deployment-gefyra    1/1   running real workload (HPA-managed)
+#
+# Generate CPU load against the shadow service to see independent scaling:
+#   SHADOW_SVC=$(kubectl get svc -l bridge.gefyra.dev/duplication-id -o jsonpath='{.items[0].metadata.name}')
+#   kubectl run loadgen --rm -it --image=busybox --restart=Never -- \
+#     /bin/sh -c "while true; do wget -q -O- http://$SHADOW_SVC; done"
+#
+# Cleanup:
+#   kubectl delete -f testing/workloads/nginx_hpa.yaml
+#   # The duplicated HPA must disappear, the original HPA stays gone too
+#   # (deleted by this manifest). The shadow deployment is removed by the
+#   # operator when the GefyraBridgeMount is deleted.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: default
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: default
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nginx-deployment-hpa
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx-deployment
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+---
+apiVersion: gefyra.dev/v1
+kind: gefyrabridgemount
+metadata:
+  name: nginx-hpa-mount
+  namespace: gefyra
+provider: carrier2mount
+targetNamespace: default
+target: deploy/nginx-deployment
+targetContainer: nginx


### PR DESCRIPTION
                                                                                                                                                                       
                                                                                                                                                                                      
For HPA-controlled deployments the shadow had two problems:                                                                                                                         
                                                                                                                                                                                    
1. **Wrong workload was scaled.** After mount, the source pods only run the lightweight Carrier2 proxy, but the existing HPA kept scaling them based on irrelevant load — and the   
operator mirrored that replica count onto the shadow. Net effect: shadow pods (running the real workload) scaled by carrier load, not real backend load.
                          
2. **Every reconcile rolled the shadow.** `_duplicate_workload()` always re-applied, even when nothing on the source had changed. For slow-starting workloads (JVM, ~30s) this      
caused repeated downtime windows on each operator tick.                                  
    
## What                                    
                                                           
- **Duplicate the HPA.** New `carrier2mount/hpa.py` discovers, clones and retargets the HPA onto `<workload>-gefyra`. Shadow scales independently from carrier. Original HPA pins the carrier pods to ~1. Removed `_scale_shadow_to_match` and the replica-mirror checks in `prepared()`/`ready()`. Cleanup uses both deterministic name and a duplication-id label sweep.
                                     
- **Idempotent re-duplication.** New `source_hash.py` hashes pod template + HPA spec (excluding replicas / volatile metadata, so HPA scale events don't invalidate). Hash is
persisted on the shadow as an annotation — survives operator restarts. On match: complete no-op, duplication-id reused (stable service selector). On mismatch: patch with           
`spec.replicas=None` so the duplicated HPA stays in charge.
- HPA support is best-effort — workloads without HPA, or clusters denying autoscaling/v2 RBAC, behave exactly as before.                                                            