### PR TITLE
fix(GO-1031): give gefyra-run containers their own PID namespace

### DIFF
--- a/client/gefyra/local/bridge.py
+++ b/client/gefyra/local/bridge.py
@@ -221,7 +221,6 @@ def deploy_app_container(
         "dns_search": dns_search,
         "auto_remove": auto_remove,
         "environment": env,
-        "pid_mode": f"container:{config.CARGO_CONTAINER_NAME}",  # noqa: E231
         "cpu_quota": cpu_quota,
         "mem_limit": mem_limit,
         "user": user,
@@ -233,7 +232,7 @@ def deploy_app_container(
     # Merge extra container engine args (e.g. --cpu-shares, --mem-reservation).
     # Extra args override built-in defaults if there is a key conflict.
     if extra_container_args:
-        _gefyra_managed_keys = {"network", "dns", "dns_search", "pid_mode", "detach"}
+        _gefyra_managed_keys = {"network", "dns", "dns_search", "detach"}
         _conflicts = [
             key for key in extra_container_args if key in _gefyra_managed_keys
         ]

--- a/client/tests/e2e/base.py
+++ b/client/tests/e2e/base.py
@@ -219,6 +219,44 @@ class GefyraBaseTest(GefyraTestMixin):
     #     self._stop_container(self.default_run_params["name"])
     #     self.kubectl("config", "set-context", "--current", "--namespace=default")
 
+    def test_c_run_gefyra_run_two_containers_isolated_pid_namespace(self):
+        # GO-1031: two gefyra-run containers must not share a PID namespace,
+        # otherwise `docker rm -f` on one cascades SIGTERM to the other.
+        self.assert_cargo_running()
+        self.assert_gefyra_connected()
+
+        names = ("gefyra-iso-one", "gefyra-iso-two")
+        for name in names:
+            self._stop_container(name)
+
+        common = {
+            "image": "alpine",
+            "command": 'sh -c "sleep 120"',
+            "namespace": "default",
+            "ports": {},
+            "detach": True,
+            "auto_remove": False,
+            "connection_name": CONNECTION_NAME,
+        }
+        try:
+            self.assertTrue(run(name=names[0], **common))
+            self.assertTrue(run(name=names[1], **common))
+
+            for name in names:
+                container = self.DOCKER_API.containers.get(name)
+                pid_mode = container.attrs["HostConfig"].get("PidMode", "")
+                self.assertFalse(
+                    pid_mode.startswith("container:"),
+                    f"{name} shares PID namespace via {pid_mode!r}",
+                )
+
+            self.DOCKER_API.containers.get(names[0]).remove(force=True)
+            sleep(3)
+            self.assert_container_running(names[1], timeout=5)
+        finally:
+            for name in names:
+                self._stop_container(name)
+
     def test_c_run_gefyra_bridge_with_invalid_deployment(self):
         self.assert_cargo_running()
         self.assert_gefyra_connected()


### PR DESCRIPTION
App containers were sharing cargo's PID namespace via pid_mode="container:gefyra-cargo", which caused `docker rm -f` on one gefyra-run container to cascade SIGTERM to all sibling containers.

The shared namespace was a leftover from the 2022 migration away from external nsenter; patchContainerGateway.sh only needs cargo's view of the host PID namespace (cargo runs pid_mode=host), not a shared namespace with the app containers. Routing via cargo continues to work unchanged after the fix.

Also drop pid_mode from the managed-keys allowlist for extra container args, since we no longer set it ourselves.