### PR TITLE
fix: create/resume for active mount

### DIFF
--- a/operator/gefyra/handler/bridge_mounts.py
+++ b/operator/gefyra/handler/bridge_mounts.py
@@ -15,6 +15,11 @@ async def bridge_mount_created(body, logger, **kwargs):
     bridge_mount = GefyraBridgeMount(
         obj, configuration, logger, initial=obj.state
     )  # Pass initial state
+    if bridge_mount.completed_transition(GefyraBridgeMount.active.value):
+        logger.info(
+            f"Skipping create/resume for GefyraBridgeMount '{bridge_mount.object_name}' (was already activated)"
+        )
+        return
 
     try:
         if bridge_mount.requested.is_active:


### PR DESCRIPTION
In case the operator is restarted it might try to resume a missing mount. Already activated mounts do not need to be activated (create/resume) again.