### PR TITLE
Security: Broad Exception Suppression

### DIFF
--- a/client/gefyra/api/operator.py
+++ b/client/gefyra/api/operator.py
@@ -23,7 +23,7 @@ def update(
             raise ClusterError(
                 f"Cannot update Gefyra operator: namespace {config.NAMESPACE} is in {ns.status.phase} state"
             )
-    except:  # noqa
+    except Exception:
         pass
 
     names = ["gefyra-operator", "gefyra-operator-webhook"]


### PR DESCRIPTION
## Summary

Security: Broad Exception Suppression

## Problem

**Severity**: `Medium` | **File**: `client/gefyra/api/operator.py:L23`

The bare `except:` clause catches all exceptions, including `SystemExit`, `KeyboardInterrupt`, and other non-Exception errors. This can mask critical errors, making debugging difficult and potentially allowing the application to continue running in an inconsistent or insecure state.

## Solution

Catch specific exceptions (e.g., `except kubernetes.client.ApiException as e:`) instead of using a bare `except:`. If a broad catch is absolutely necessary, use `except Exception:` to avoid catching system-exiting exceptions.

## Changes

- `client/gefyra/api/operator.py` (modified)